### PR TITLE
Drop entry acl

### DIFF
--- a/Dbal/AclProvider.php
+++ b/Dbal/AclProvider.php
@@ -75,6 +75,15 @@ class AclProvider implements AclProviderInterface
     /**
      * {@inheritdoc}
      */
+    public function releaseMemory()
+    {
+        $this->loadedAces = array();
+        $this->loadedAcls = array();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function findChildren(ObjectIdentityInterface $parentOid, $directChildrenOnly = false)
     {
         $sql = $this->getFindChildrenSql($parentOid, $directChildrenOnly);

--- a/Dbal/MutableAclProvider.php
+++ b/Dbal/MutableAclProvider.php
@@ -49,6 +49,15 @@ class MutableAclProvider extends AclProvider implements MutableAclProviderInterf
     /**
      * {@inheritdoc}
      */
+    public function releaseMemory()
+    {
+        parent::releaseMemory();
+        $this->propertyChanges = new \SplObjectStorage();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function createAcl(ObjectIdentityInterface $oid)
     {
         if (false !== $this->retrieveObjectIdentityPrimaryKey($oid)) {

--- a/Dbal/MutableAclProvider.php
+++ b/Dbal/MutableAclProvider.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Security\Acl\Dbal;
 
 use Doctrine\Common\PropertyChangedListener;
 use Doctrine\DBAL\Connection;
+use Symfony\Component\Security\Acl\Domain\AclEntry;
 use Symfony\Component\Security\Acl\Domain\RoleSecurityIdentity;
 use Symfony\Component\Security\Acl\Domain\UserSecurityIdentity;
 use Symfony\Component\Security\Acl\Exception\AclAlreadyExistsException;
@@ -170,13 +171,13 @@ class MutableAclProvider extends AclProvider implements MutableAclProviderInterf
             throw new \InvalidArgumentException('$sender must be an instance of MutableAclInterface, or EntryInterface.');
         }
 
-        if ($sender instanceof EntryInterface) {
-            if (null === $sender->getId()) {
+        if ($sender instanceof AclEntry) {
+            if (null === $sender->getEntry()->getId()) {
                 return;
             }
 
-            $ace = $sender;
-            $sender = $ace->getAcl();
+            $ace = $sender->getEntry();
+            $sender = $sender->getAcl();
         } else {
             $ace = null;
         }

--- a/Domain/Acl.php
+++ b/Domain/Acl.php
@@ -485,7 +485,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
             }
         }
 
-        $aces[$index] = new Entry(null, $this, $sid, $strategy, $mask, $granting, false, false);
+        $aces[$index] = new Entry(null, $sid, $strategy, $mask, $granting, false, false);
         $this->onPropertyChanged($property, $oldValue, $this->$property);
     }
 
@@ -543,7 +543,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
             }
         }
 
-        $aces[$field][$index] = new FieldEntry(null, $this, $field, $sid, $strategy, $mask, $granting, false, false);
+        $aces[$field][$index] = new FieldEntry(null, $field, $sid, $strategy, $mask, $granting, false, false);
         $this->onPropertyChanged($property, $oldValue, $this->$property);
     }
 
@@ -620,7 +620,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
             throw new \InvalidArgumentException('$field cannot be empty.');
         }
 
-        $aces = &$this->$property;
+        $aces = $this->$property;
         if (!isset($aces[$field][$index])) {
             throw new \OutOfBoundsException(sprintf('The index "%d" does not exist.', $index));
         }
@@ -661,7 +661,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     private function onEntryPropertyChanged(EntryInterface $entry, $name, $oldValue, $newValue)
     {
         foreach ($this->listeners as $listener) {
-            $listener->propertyChanged($entry, $name, $oldValue, $newValue);
+            $listener->propertyChanged(new AclEntry($this, $entry), $name, $oldValue, $newValue);
         }
     }
 }

--- a/Domain/AclEntry.php
+++ b/Domain/AclEntry.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Acl\Domain;
+
+use Symfony\Component\Security\Acl\Model\AclInterface;
+use Symfony\Component\Security\Acl\Model\EntryInterface;
+
+/**
+ * AclEntry
+ *
+ * @author Evgeniy Sokolov <ewgraf@gmail.com>
+ */
+class AclEntry
+{
+    private $acl;
+    private $entry;
+
+    public function __construct(AclInterface $acl, EntryInterface $entry)
+    {
+        $this->acl = $acl;
+        $this->entry = $entry;
+    }
+
+    public function getAcl()
+    {
+        return $this->acl;
+    }
+
+    public function getEntry()
+    {
+        return $this->entry;
+    }
+}

--- a/Domain/DoctrineAclCache.php
+++ b/Domain/DoctrineAclCache.php
@@ -169,36 +169,6 @@ class DoctrineAclCache implements AclCacheInterface
         $reflectionProperty->setValue($acl, $this->permissionGrantingStrategy);
         $reflectionProperty->setAccessible(false);
 
-        $aceAclProperty = new \ReflectionProperty('Symfony\Component\Security\Acl\Domain\Entry', 'acl');
-        $aceAclProperty->setAccessible(true);
-
-        foreach ($acl->getObjectAces() as $ace) {
-            $aceAclProperty->setValue($ace, $acl);
-        }
-        foreach ($acl->getClassAces() as $ace) {
-            $aceAclProperty->setValue($ace, $acl);
-        }
-
-        $aceClassFieldProperty = new \ReflectionProperty($acl, 'classFieldAces');
-        $aceClassFieldProperty->setAccessible(true);
-        foreach ($aceClassFieldProperty->getValue($acl) as $aces) {
-            foreach ($aces as $ace) {
-                $aceAclProperty->setValue($ace, $acl);
-            }
-        }
-        $aceClassFieldProperty->setAccessible(false);
-
-        $aceObjectFieldProperty = new \ReflectionProperty($acl, 'objectFieldAces');
-        $aceObjectFieldProperty->setAccessible(true);
-        foreach ($aceObjectFieldProperty->getValue($acl) as $aces) {
-            foreach ($aces as $ace) {
-                $aceAclProperty->setValue($ace, $acl);
-            }
-        }
-        $aceObjectFieldProperty->setAccessible(false);
-
-        $aceAclProperty->setAccessible(false);
-
         return $acl;
     }
 

--- a/Domain/Entry.php
+++ b/Domain/Entry.php
@@ -22,7 +22,6 @@ use Symfony\Component\Security\Acl\Model\SecurityIdentityInterface;
  */
 class Entry implements AuditableEntryInterface
 {
-    private $acl;
     private $mask;
     private $id;
     private $securityIdentity;
@@ -35,7 +34,6 @@ class Entry implements AuditableEntryInterface
      * Constructor.
      *
      * @param int                       $id
-     * @param AclInterface              $acl
      * @param SecurityIdentityInterface $sid
      * @param string                    $strategy
      * @param int                       $mask
@@ -43,24 +41,15 @@ class Entry implements AuditableEntryInterface
      * @param bool                      $auditFailure
      * @param bool                      $auditSuccess
      */
-    public function __construct($id, AclInterface $acl, SecurityIdentityInterface $sid, $strategy, $mask, $granting, $auditFailure, $auditSuccess)
+    public function __construct($id, SecurityIdentityInterface $sid, $strategy, $mask, $granting, $auditFailure, $auditSuccess)
     {
         $this->id = $id;
-        $this->acl = $acl;
         $this->securityIdentity = $sid;
         $this->strategy = $strategy;
         $this->mask = $mask;
         $this->granting = $granting;
         $this->auditFailure = $auditFailure;
         $this->auditSuccess = $auditSuccess;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getAcl()
-    {
-        return $this->acl;
     }
 
     /**

--- a/Domain/FieldEntry.php
+++ b/Domain/FieldEntry.php
@@ -28,7 +28,6 @@ class FieldEntry extends Entry implements FieldEntryInterface
      * Constructor.
      *
      * @param int                       $id
-     * @param AclInterface              $acl
      * @param string                    $field
      * @param SecurityIdentityInterface $sid
      * @param string                    $strategy
@@ -37,9 +36,9 @@ class FieldEntry extends Entry implements FieldEntryInterface
      * @param bool                      $auditFailure
      * @param bool                      $auditSuccess
      */
-    public function __construct($id, AclInterface $acl, $field, SecurityIdentityInterface $sid, $strategy, $mask, $granting, $auditFailure, $auditSuccess)
+    public function __construct($id, $field, SecurityIdentityInterface $sid, $strategy, $mask, $granting, $auditFailure, $auditSuccess)
     {
-        parent::__construct($id, $acl, $sid, $strategy, $mask, $granting, $auditFailure, $auditSuccess);
+        parent::__construct($id, $sid, $strategy, $mask, $granting, $auditFailure, $auditSuccess);
 
         $this->field = $field;
     }

--- a/Model/AclProviderInterface.php
+++ b/Model/AclProviderInterface.php
@@ -53,4 +53,11 @@ interface AclProviderInterface
      * @throws AclNotFoundException when we cannot find an ACL for all identities
      */
     public function findAcls(array $oids, array $sids = array());
+
+    /**
+     * AclProvider for better performance can save some information in memory.
+     * You can ask provider to free this memory if you perform many calls
+     * @return void
+     */
+    public function releaseMemory();
 }

--- a/Model/EntryInterface.php
+++ b/Model/EntryInterface.php
@@ -22,13 +22,6 @@ namespace Symfony\Component\Security\Acl\Model;
 interface EntryInterface extends \Serializable
 {
     /**
-     * The ACL this ACE is associated with.
-     *
-     * @return AclInterface
-     */
-    public function getAcl();
-
-    /**
      * The primary key of this ACE.
      *
      * @return int

--- a/Tests/Domain/AclTest.php
+++ b/Tests/Domain/AclTest.php
@@ -491,7 +491,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
         $listener = $this->getMock('Doctrine\Common\PropertyChangedListener');
         foreach ($expectedChanges as $index => $property) {
             if (in_array($property, $aceProperties)) {
-                $class = 'Symfony\Component\Security\Acl\Domain\Entry';
+                $class = 'Symfony\Component\Security\Acl\Domain\AclEntry';
             } else {
                 $class = 'Symfony\Component\Security\Acl\Domain\Acl';
             }

--- a/Tests/Domain/EntryTest.php
+++ b/Tests/Domain/EntryTest.php
@@ -17,10 +17,9 @@ class EntryTest extends \PHPUnit_Framework_TestCase
 {
     public function testConstructor()
     {
-        $ace = $this->getAce($acl = $this->getAcl(), $sid = $this->getSid());
+        $ace = $this->getAce($sid = $this->getSid());
 
         $this->assertEquals(123, $ace->getId());
-        $this->assertSame($acl, $ace->getAcl());
         $this->assertSame($sid, $ace->getSecurityIdentity());
         $this->assertEquals('foostrat', $ace->getStrategy());
         $this->assertEquals(123456, $ace->getMask());
@@ -76,7 +75,6 @@ class EntryTest extends \PHPUnit_Framework_TestCase
         $serialized = serialize($ace);
         $uAce = unserialize($serialized);
 
-        $this->assertNull($uAce->getAcl());
         $this->assertInstanceOf('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface', $uAce->getSecurityIdentity());
         $this->assertEquals($ace->getId(), $uAce->getId());
         $this->assertEquals($ace->getMask(), $uAce->getMask());
@@ -86,18 +84,14 @@ class EntryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($ace->isAuditFailure(), $uAce->isAuditFailure());
     }
 
-    protected function getAce($acl = null, $sid = null)
+    protected function getAce($sid = null)
     {
-        if (null === $acl) {
-            $acl = $this->getAcl();
-        }
         if (null === $sid) {
             $sid = $this->getSid();
         }
 
         return new Entry(
             123,
-            $acl,
             $sid,
             'foostrat',
             123456,
@@ -105,11 +99,6 @@ class EntryTest extends \PHPUnit_Framework_TestCase
             false,
             true
         );
-    }
-
-    protected function getAcl()
-    {
-        return $this->getMock('Symfony\Component\Security\Acl\Model\AclInterface');
     }
 
     protected function getSid()

--- a/Tests/Domain/FieldEntryTest.php
+++ b/Tests/Domain/FieldEntryTest.php
@@ -29,7 +29,6 @@ class FieldEntryTest extends \PHPUnit_Framework_TestCase
         $serialized = serialize($ace);
         $uAce = unserialize($serialized);
 
-        $this->assertNull($uAce->getAcl());
         $this->assertInstanceOf('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface', $uAce->getSecurityIdentity());
         $this->assertEquals($ace->getId(), $uAce->getId());
         $this->assertEquals($ace->getField(), $uAce->getField());
@@ -40,18 +39,14 @@ class FieldEntryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($ace->isAuditFailure(), $uAce->isAuditFailure());
     }
 
-    protected function getAce($acl = null, $sid = null)
+    protected function getAce($sid = null)
     {
-        if (null === $acl) {
-            $acl = $this->getAcl();
-        }
         if (null === $sid) {
             $sid = $this->getSid();
         }
 
         return new FieldEntry(
             123,
-            $acl,
             'foo',
             $sid,
             'foostrat',
@@ -60,11 +55,6 @@ class FieldEntryTest extends \PHPUnit_Framework_TestCase
             false,
             true
         );
-    }
-
-    protected function getAcl()
-    {
-        return $this->getMock('Symfony\Component\Security\Acl\Model\AclInterface');
     }
 
     protected function getSid()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | -
| Fixed tickets | https://github.com/symfony/symfony/issues/2376
| License       | MIT
| Doc PR        | 

As I notice in https://github.com/symfony/symfony/issues/2376, Acl have memory leak.

This is kind of bad design of code, that use something like this:
$this->entry = new Entry(this);

as a result Acl have refcount=2, and second refcount from object itself. As a result when we do unset($acl) it is not free memory at all. This PR - fix for this.