### PR TITLE
Test to show FieldEntry serialization bug and a fix proposal

### DIFF
--- a/Domain/Entry.php
+++ b/Domain/Entry.php
@@ -181,7 +181,9 @@ class Entry implements AuditableEntryInterface
         return serialize(array(
             $this->mask,
             $this->id,
-            $this->securityIdentity,
+            // clone due to the unserialize issue in php 5.4-5.6
+            // when Acl has few FieldEntry objects with the same SecurityIdentityInterface instance
+            clone $this->securityIdentity,
             $this->strategy,
             $this->auditFailure,
             $this->auditSuccess,

--- a/Tests/Domain/FieldEntryTest.php
+++ b/Tests/Domain/FieldEntryTest.php
@@ -40,6 +40,37 @@ class FieldEntryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($ace->isAuditFailure(), $uAce->isAuditFailure());
     }
 
+    public function testSerializeUnserializeMoreAceWithSameSecurityIdentity()
+    {
+        $sid = $this->getSid();
+
+        $aceFirst = $this->getAce(null, $sid);
+        $aceSecond = $this->getAce(null, $sid);
+
+        $serializedFirst = serialize(array($aceFirst, $aceSecond));
+        list($uAceFirst, $uAceSecond) = unserialize($serializedFirst);
+
+        $this->assertNull($uAceFirst->getAcl());
+        $this->assertInstanceOf('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface', $uAceFirst->getSecurityIdentity());
+        $this->assertEquals($aceFirst->getId(), $uAceFirst->getId());
+        $this->assertEquals($aceFirst->getField(), $uAceFirst->getField());
+        $this->assertEquals($aceFirst->getMask(), $uAceFirst->getMask());
+        $this->assertEquals($aceFirst->getStrategy(), $uAceFirst->getStrategy());
+        $this->assertEquals($aceFirst->isGranting(), $uAceFirst->isGranting());
+        $this->assertEquals($aceFirst->isAuditSuccess(), $uAceFirst->isAuditSuccess());
+        $this->assertEquals($aceFirst->isAuditFailure(), $uAceFirst->isAuditFailure());
+
+        $this->assertNull($uAceSecond->getAcl());
+        $this->assertInstanceOf('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface', $uAceSecond->getSecurityIdentity());
+        $this->assertEquals($aceSecond->getId(), $uAceSecond->getId());
+        $this->assertEquals($aceSecond->getField(), $uAceSecond->getField());
+        $this->assertEquals($aceSecond->getMask(), $uAceSecond->getMask());
+        $this->assertEquals($aceSecond->getStrategy(), $uAceSecond->getStrategy());
+        $this->assertEquals($aceSecond->isGranting(), $uAceSecond->isGranting());
+        $this->assertEquals($aceSecond->isAuditSuccess(), $uAceSecond->isAuditSuccess());
+        $this->assertEquals($aceSecond->isAuditFailure(), $uAceSecond->isAuditFailure());
+    }
+
     protected function getAce($acl = null, $sid = null)
     {
         if (null === $acl) {

--- a/Tests/Domain/FieldEntryTest.php
+++ b/Tests/Domain/FieldEntryTest.php
@@ -40,6 +40,9 @@ class FieldEntryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($ace->isAuditFailure(), $uAce->isAuditFailure());
     }
 
+    /**
+     * Test that two FieldEntry objects correctly serialized and unserialized
+     */
     public function testSerializeUnserializeMoreAceWithSameSecurityIdentity()
     {
         $sid = $this->getSid();
@@ -61,29 +64,14 @@ class FieldEntryTest extends \PHPUnit_Framework_TestCase
         $uAceFirst  = $unserialized[0]['fieldOne'][0];
         $uAceSecond = $unserialized[0]['fieldTwo'][0];
 
-
-        $this->assertNull($uAceFirst->getAcl());
-        $this->assertInstanceOf('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface', $uAceFirst->getSecurityIdentity());
-        $this->assertEquals($aceFirst->getId(), $uAceFirst->getId());
-        $this->assertEquals($aceFirst->getField(), $uAceFirst->getField());
-        $this->assertEquals($aceFirst->getMask(), $uAceFirst->getMask());
-        $this->assertEquals($aceFirst->getStrategy(), $uAceFirst->getStrategy());
-        $this->assertEquals($aceFirst->isGranting(), $uAceFirst->isGranting());
-        $this->assertEquals($aceFirst->isAuditSuccess(), $uAceFirst->isAuditSuccess());
-        $this->assertEquals($aceFirst->isAuditFailure(), $uAceFirst->isAuditFailure());
-
-        $this->assertNull($uAceSecond->getAcl());
-
-        // Bug: this will fail, securityIdentity is FieldEntry
-        $this->assertInstanceOf('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface', $uAceSecond->getSecurityIdentity());
-        
-        $this->assertEquals($aceSecond->getId(), $uAceSecond->getId());
-        $this->assertEquals($aceSecond->getField(), $uAceSecond->getField());
-        $this->assertEquals($aceSecond->getMask(), $uAceSecond->getMask());
-        $this->assertEquals($aceSecond->getStrategy(), $uAceSecond->getStrategy());
-        $this->assertEquals($aceSecond->isGranting(), $uAceSecond->isGranting());
-        $this->assertEquals($aceSecond->isAuditSuccess(), $uAceSecond->isAuditSuccess());
-        $this->assertEquals($aceSecond->isAuditFailure(), $uAceSecond->isAuditFailure());
+        $this->assertInstanceOf(
+            'Symfony\Component\Security\Acl\Model\SecurityIdentityInterface',
+            $uAceFirst->getSecurityIdentity()
+        );
+        $this->assertInstanceOf(
+            'Symfony\Component\Security\Acl\Model\SecurityIdentityInterface',
+            $uAceSecond->getSecurityIdentity()
+        );
     }
 
     protected function getAce($acl = null, $sid = null)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #9 |
| License | MIT |
| Doc PR |  |

According to @alipek:
"This commit show problem with serialize Acl with many FieldEntry objects contains same sid."
https://github.com/symfony/symfony/pull/12873
and issue created in symfony repo https://github.com/symfony/symfony/issues/12875 and closed cause of acl component was moved into separate repository.
