### PR TITLE
Fix Entry serialization

### DIFF
--- a/Domain/Entry.php
+++ b/Domain/Entry.php
@@ -191,6 +191,10 @@ class Entry implements AuditableEntryInterface
         $this->setSerializeData(unserialize($serialized));
     }
 
+    /**
+     * Get data for serialize
+     * @return array
+     */
     protected function getSerializeData()
     {
         return array(
@@ -204,6 +208,10 @@ class Entry implements AuditableEntryInterface
         );
     }
 
+    /**
+     * Set unserialized data
+     * @param array $array Array of serialized data
+     */
     protected function setSerializeData(array $array)
     {
         list($this->mask,

--- a/Domain/Entry.php
+++ b/Domain/Entry.php
@@ -178,15 +178,7 @@ class Entry implements AuditableEntryInterface
      */
     public function serialize()
     {
-        return serialize(array(
-            $this->mask,
-            $this->id,
-            $this->securityIdentity,
-            $this->strategy,
-            $this->auditFailure,
-            $this->auditSuccess,
-            $this->granting,
-        ));
+        return serialize($this->getSerializeData());
     }
 
     /**
@@ -196,13 +188,31 @@ class Entry implements AuditableEntryInterface
      */
     public function unserialize($serialized)
     {
+        $this->setSerializeData(unserialize($serialized));
+    }
+
+    protected function getSerializeData()
+    {
+        return array(
+            $this->mask,
+            $this->id,
+            $this->securityIdentity,
+            $this->strategy,
+            $this->auditFailure,
+            $this->auditSuccess,
+            $this->granting
+        );
+    }
+
+    protected function setSerializeData(array $array)
+    {
         list($this->mask,
-             $this->id,
-             $this->securityIdentity,
-             $this->strategy,
-             $this->auditFailure,
-             $this->auditSuccess,
-             $this->granting
-        ) = unserialize($serialized);
+            $this->id,
+            $this->securityIdentity,
+            $this->strategy,
+            $this->auditFailure,
+            $this->auditSuccess,
+            $this->granting
+        ) = $array;
     }
 }

--- a/Domain/FieldEntry.php
+++ b/Domain/FieldEntry.php
@@ -52,11 +52,17 @@ class FieldEntry extends Entry implements FieldEntryInterface
         return $this->field;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     protected function getSerializeData()
     {
         return array($this->field, parent::getSerializeData());
     }
 
+    /**
+     * {@inheritdoc}
+     */
     protected function setSerializeData(array $array)
     {
         $this->field = $array[0];

--- a/Domain/FieldEntry.php
+++ b/Domain/FieldEntry.php
@@ -27,15 +27,15 @@ class FieldEntry extends Entry implements FieldEntryInterface
     /**
      * Constructor.
      *
-     * @param int                       $id
-     * @param AclInterface              $acl
-     * @param string                    $field
+     * @param int $id
+     * @param AclInterface $acl
+     * @param string $field
      * @param SecurityIdentityInterface $sid
-     * @param string                    $strategy
-     * @param int                       $mask
-     * @param bool                      $granting
-     * @param bool                      $auditFailure
-     * @param bool                      $auditSuccess
+     * @param string $strategy
+     * @param int $mask
+     * @param bool $granting
+     * @param bool $auditFailure
+     * @param bool $auditSuccess
      */
     public function __construct($id, AclInterface $acl, $field, SecurityIdentityInterface $sid, $strategy, $mask, $granting, $auditFailure, $auditSuccess)
     {
@@ -52,23 +52,14 @@ class FieldEntry extends Entry implements FieldEntryInterface
         return $this->field;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function serialize()
+    protected function getSerializeData()
     {
-        return serialize(array(
-            $this->field,
-            parent::serialize(),
-        ));
+        return array($this->field, parent::getSerializeData());
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function unserialize($serialized)
+    protected function setSerializeData(array $array)
     {
-        list($this->field, $parentStr) = unserialize($serialized);
-        parent::unserialize($parentStr);
+        $this->field = $array[0];
+        parent::setSerializeData($array[1]);
     }
 }

--- a/Domain/FieldEntry.php
+++ b/Domain/FieldEntry.php
@@ -54,7 +54,6 @@ class FieldEntry extends Entry implements FieldEntryInterface
 
     /**
      * {@inheritdoc}
-     *
      */
     public function unserialize($serialized)
     {

--- a/Domain/FieldEntry.php
+++ b/Domain/FieldEntry.php
@@ -54,6 +54,23 @@ class FieldEntry extends Entry implements FieldEntryInterface
 
     /**
      * {@inheritdoc}
+     *
+     */
+    public function unserialize($serialized)
+    {
+        # Legacy support
+        $unserialized = unserialize($serialized);
+
+        if (is_string($unserialized[1])) {
+            $unserialized[1] = unserialize($unserialized[1]);
+            $this->setSerializeData($unserialized);
+        }
+
+        $this->setSerializeData($unserialized);
+    }
+
+    /**
+     * {@inheritdoc}
      */
     protected function getSerializeData()
     {

--- a/Tests/Domain/FieldEntryTest.php
+++ b/Tests/Domain/FieldEntryTest.php
@@ -22,6 +22,21 @@ class FieldEntryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $ace->getField());
     }
 
+    public function testSerializeUnserializeSameSecurityIdentity()
+    {
+        $sid = $this->getSid();
+
+        $aceFirst = $this->getAce(null, $sid);
+        $aceSecond = $this->getAce(null, $sid);
+
+        /** @var FieldEntry $uAceFirst */
+        /** @var FieldEntry $uAceSecond */
+        list($uAceFirst, $uAceSecond) = unserialize(serialize(array($aceFirst, $aceSecond)));
+
+        $this->assertInstanceOf('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface', $uAceFirst->getSecurityIdentity());
+        $this->assertSame($uAceFirst->getSecurityIdentity(), $uAceSecond->getSecurityIdentity());
+    }
+
     public function testSerializeUnserialize()
     {
         $ace = $this->getAce();

--- a/Tests/Domain/FieldEntryTest.php
+++ b/Tests/Domain/FieldEntryTest.php
@@ -37,6 +37,15 @@ class FieldEntryTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($uAceFirst->getSecurityIdentity(), $uAceSecond->getSecurityIdentity());
     }
 
+    public function testUnserializeLegacy()
+    {
+        $serialized = 'C:48:"Symfony\Component\Security\Acl\Domain\FieldEntry":300:{a:2:{i:0;s:5:"field";i:1;s:265:"a:7:{i:0;s:4:"mask";i:1;i:1;i:2;O:20:"SecurityEdentityMock":2:{s:48:" SecurityEdentityMock __phpunit_invocationMocker";N;s:46:" SecurityEdentityMock __phpunit_originalObject";N;}i:3;s:8:"strategy";i:4;s:12:"auditFailure";i:5;s:12:"auditSuccess";i:6;s:8:"granting";}";}}';
+        $ace = unserialize($serialized);
+        $this->assertNull($ace->getAcl());
+        $this->assertEquals(1, $ace->getId());
+        $this->assertEquals('field', $ace->getField());
+    }
+
     public function testSerializeUnserialize()
     {
         $ace = $this->getAce();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | probably |
| Deprecations? | no |
| Tests pass? | - |
| Fixed tickets | https://github.com/symfony/security-acl/issues/9 |
| License | MIT |
| Doc PR |  |

I'm not sure that it is not BC breaks. Also as for people who extends from FieldEntry for example and will be use unserialize bug will be not fixed. But I don't see better solution for this bug. 
If it is BC break, than better drop legacy support at all.
