### PR TITLE
Depend on AuthenticationTrustResolverInterface

### DIFF
--- a/Domain/SecurityIdentityRetrievalStrategy.php
+++ b/Domain/SecurityIdentityRetrievalStrategy.php
@@ -11,10 +11,10 @@
 
 namespace Symfony\Component\Security\Acl\Domain;
 
+use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Acl\Model\SecurityIdentityRetrievalStrategyInterface;
-use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolver;
 use Symfony\Component\Security\Core\Role\RoleHierarchyInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 
@@ -31,10 +31,10 @@ class SecurityIdentityRetrievalStrategy implements SecurityIdentityRetrievalStra
     /**
      * Constructor.
      *
-     * @param RoleHierarchyInterface      $roleHierarchy
-     * @param AuthenticationTrustResolver $authenticationTrustResolver
+     * @param RoleHierarchyInterface               $roleHierarchy
+     * @param AuthenticationTrustResolverInterface $authenticationTrustResolver
      */
-    public function __construct(RoleHierarchyInterface $roleHierarchy, AuthenticationTrustResolver $authenticationTrustResolver)
+    public function __construct(RoleHierarchyInterface $roleHierarchy, AuthenticationTrustResolverInterface $authenticationTrustResolver)
     {
         $this->roleHierarchy = $roleHierarchy;
         $this->authenticationTrustResolver = $authenticationTrustResolver;

--- a/Tests/Domain/SecurityIdentityRetrievalStrategyTest.php
+++ b/Tests/Domain/SecurityIdentityRetrievalStrategyTest.php
@@ -129,7 +129,7 @@ class SecurityIdentityRetrievalStrategyTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($roles))
         ;
 
-        $trustResolver = $this->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolver', array(), array('', ''));
+        $trustResolver = $this->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface', array(), array('', ''));
 
         $trustResolver
             ->expects($this->at(0))


### PR DESCRIPTION
SecurityIdentityRetrievalStrategy should depend on AuthenticationTrustResolverInterface, otherwise it's not possible to use any alternative implementation.

I'd also suggest to backport this at least to 2.8.
