### PR TITLE
Add doctrine/common to suggested packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     "suggest": {
         "symfony/class-loader": "For using the ACL generateSql script",
         "symfony/finder": "For using the ACL generateSql script",
+        "doctrine/common": "For using the built-in ACL implementation",
         "doctrine/dbal": "For using the built-in ACL implementation"
     },
     "autoload": {


### PR DESCRIPTION
doctrine/common used to be a doctrine/dbal dependency, but that’s not
true anymore as of version 2.8.0 of doctrine/dbal. Yet, there are some
"use Doctrine\Common\…" in Domain/Acl.php and other places.