### PR TITLE
Remove mask EDIT from permission VIEW

### DIFF
--- a/Permission/BasicPermissionMap.php
+++ b/Permission/BasicPermissionMap.php
@@ -35,7 +35,6 @@ class BasicPermissionMap implements PermissionMapInterface, MaskBuilderRetrieval
         $this->map = array(
             self::PERMISSION_VIEW => array(
                 MaskBuilder::MASK_VIEW,
-                MaskBuilder::MASK_EDIT,
                 MaskBuilder::MASK_OPERATOR,
                 MaskBuilder::MASK_MASTER,
                 MaskBuilder::MASK_OWNER,


### PR DESCRIPTION
Permission VIEW contains mask EDIT. But for me it looks like a bug.

A user with just EDIT acl can getting access for this : `is_granted('VIEW', object)`

But it should not.