### PR TITLE
Fixed Symfony 4.3 deprecated messages

### DIFF
--- a/Tests/Domain/SecurityIdentityRetrievalStrategyTest.php
+++ b/Tests/Domain/SecurityIdentityRetrievalStrategyTest.php
@@ -38,11 +38,21 @@ class SecurityIdentityRetrievalStrategyTest extends \PHPUnit_Framework_TestCase
                         ->setMockClassName($class)
                         ->getMock();
         }
-        $token
-            ->expects($this->once())
-            ->method('getRoles')
-            ->will($this->returnValue(array('foo')))
-        ;
+
+        if (method_exists($token, 'getRoleNames')) {
+            $token
+                ->expects($this->once())
+                ->method('getRoleNames')
+                ->will($this->returnValue(array('foo')))
+            ;
+        } else {
+            $token
+                ->expects($this->once())
+                ->method('getRoles')
+                ->will($this->returnValue(array('foo')))
+            ;
+        }
+
         if ('anonymous' === $authenticationStatus) {
             $token
                 ->expects($this->never())


### PR DESCRIPTION
This should resolve the following errors:

> The getReachableRoles() method of the RoleHierarchyInterface is deprecated
> The getRoles() method of the TokenInterface is deprecated