### PR TITLE
Fixed Symfony 4.3 wrong role variable type

### DIFF
--- a/Domain/SecurityIdentityRetrievalStrategy.php
+++ b/Domain/SecurityIdentityRetrievalStrategy.php
@@ -58,14 +58,13 @@ class SecurityIdentityRetrievalStrategy implements SecurityIdentityRetrievalStra
         }
 
         // add all reachable roles
-        $roles = $this->getRoleNames($token);
         if (method_exists($this->roleHierarchy, 'getReachableRoleNames')) {
-            foreach ($this->roleHierarchy->getReachableRoleNames($roles) as $role) {
+            foreach ($this->roleHierarchy->getReachableRoleNames($this->getRoleNames($token)) as $role) {
                 $sids[] = new RoleSecurityIdentity($role);
             }
         } else {
             // Symfony < 4.3 BC layer
-            foreach ($this->roleHierarchy->getReachableRoles($roles) as $role) {
+            foreach ($this->roleHierarchy->getReachableRoles($token->getRoles()) as $role) {
                 $sids[] = new RoleSecurityIdentity($role);
             }
         }
@@ -85,7 +84,7 @@ class SecurityIdentityRetrievalStrategy implements SecurityIdentityRetrievalStra
         return $sids;
     }
 
-    private function getRoleNames(TokenInterface $token): array
+    private function getRoleNames(TokenInterface $token)
     {
         if (method_exists($token, 'getRoleNames')) {
             return $token->getRoleNames();


### PR DESCRIPTION
This should fix work in symfony < 4.3

Original error from logs symfony 3.4 application:
```
Uncaught PHP Exception Symfony\Component\Debug\Exception\FatalThrowableError:
"Call to a member function getRole() on string" at
vendor/symfony/symfony/src/Symfony/Component/Security/Core/Role/RoleHierarchy.php line 41
{"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0):
Call to a member function getRole() on string at
vendor/symfony/symfony/src/Symfony/Component/Security/Core/Role/RoleHierarchy.php:41
```

Found in https://github.com/symfony/security-acl/pull/50#discussion_r356847257