### PR TITLE
fix: change executeQuery method to executeUpdate for writing operations

### DIFF
--- a/Dbal/MutableAclProvider.php
+++ b/Dbal/MutableAclProvider.php
@@ -60,7 +60,7 @@ class MutableAclProvider extends AclProvider implements MutableAclProviderInterf
             $this->createObjectIdentity($oid);
 
             $pk = $this->retrieveObjectIdentityPrimaryKey($oid);
-            $this->connection->executeQuery($this->getInsertObjectIdentityRelationSql($pk, $pk));
+            $this->connection->executeUpdate($this->getInsertObjectIdentityRelationSql($pk, $pk));
 
             $this->connection->commit();
         } catch (\Exception $e) {
@@ -119,7 +119,7 @@ class MutableAclProvider extends AclProvider implements MutableAclProviderInterf
      */
     public function deleteSecurityIdentity(SecurityIdentityInterface $sid)
     {
-        $this->connection->executeQuery($this->getDeleteSecurityIdentityIdSql($sid));
+        $this->connection->executeUpdate($this->getDeleteSecurityIdentityIdSql($sid));
     }
 
     /**
@@ -334,7 +334,7 @@ class MutableAclProvider extends AclProvider implements MutableAclProviderInterf
 
             // persist any changes to the acl_object_identities table
             if (count($sets) > 0) {
-                $this->connection->executeQuery($this->getUpdateObjectIdentitySql($acl->getId(), $sets));
+                $this->connection->executeUpdate($this->getUpdateObjectIdentitySql($acl->getId(), $sets));
             }
 
             $this->connection->commit();
@@ -373,7 +373,7 @@ class MutableAclProvider extends AclProvider implements MutableAclProviderInterf
      */
     public function updateUserSecurityIdentity(UserSecurityIdentity $usid, $oldUsername)
     {
-        $this->connection->executeQuery($this->getUpdateUserSecurityIdentitySql($usid, $oldUsername));
+        $this->connection->executeUpdate($this->getUpdateUserSecurityIdentitySql($usid, $oldUsername));
     }
 
     /**
@@ -750,7 +750,7 @@ QUERY;
     {
         $classId = $this->createOrRetrieveClassId($oid->getType());
 
-        $this->connection->executeQuery($this->getInsertObjectIdentitySql($oid->getIdentifier(), $classId, true));
+        $this->connection->executeUpdate($this->getInsertObjectIdentitySql($oid->getIdentifier(), $classId, true));
     }
 
     /**
@@ -768,7 +768,7 @@ QUERY;
             return $id;
         }
 
-        $this->connection->executeQuery($this->getInsertClassSql($classType));
+        $this->connection->executeUpdate($this->getInsertClassSql($classType));
 
         return $this->connection->executeQuery($this->getSelectClassIdSql($classType))->fetchColumn();
     }
@@ -789,7 +789,7 @@ QUERY;
             return $id;
         }
 
-        $this->connection->executeQuery($this->getInsertSecurityIdentitySql($sid));
+        $this->connection->executeUpdate($this->getInsertSecurityIdentitySql($sid));
 
         return $this->connection->executeQuery($this->getSelectSecurityIdentityIdSql($sid))->fetchColumn();
     }
@@ -801,7 +801,7 @@ QUERY;
      */
     private function deleteAccessControlEntries($oidPK)
     {
-        $this->connection->executeQuery($this->getDeleteAccessControlEntriesSql($oidPK));
+        $this->connection->executeUpdate($this->getDeleteAccessControlEntriesSql($oidPK));
     }
 
     /**
@@ -811,7 +811,7 @@ QUERY;
      */
     private function deleteObjectIdentity($pk)
     {
-        $this->connection->executeQuery($this->getDeleteObjectIdentitySql($pk));
+        $this->connection->executeUpdate($this->getDeleteObjectIdentitySql($pk));
     }
 
     /**
@@ -821,7 +821,7 @@ QUERY;
      */
     private function deleteObjectIdentityRelations($pk)
     {
-        $this->connection->executeQuery($this->getDeleteObjectIdentityRelationsSql($pk));
+        $this->connection->executeUpdate($this->getDeleteObjectIdentityRelationsSql($pk));
     }
 
     /**
@@ -832,12 +832,12 @@ QUERY;
     private function regenerateAncestorRelations(AclInterface $acl)
     {
         $pk = $acl->getId();
-        $this->connection->executeQuery($this->getDeleteObjectIdentityRelationsSql($pk));
-        $this->connection->executeQuery($this->getInsertObjectIdentityRelationSql($pk, $pk));
+        $this->connection->executeUpdate($this->getDeleteObjectIdentityRelationsSql($pk));
+        $this->connection->executeUpdate($this->getInsertObjectIdentityRelationSql($pk, $pk));
 
         $parentAcl = $acl->getParentAcl();
         while (null !== $parentAcl) {
-            $this->connection->executeQuery($this->getInsertObjectIdentityRelationSql($pk, $parentAcl->getId()));
+            $this->connection->executeUpdate($this->getInsertObjectIdentityRelationSql($pk, $parentAcl->getId()));
 
             $parentAcl = $parentAcl->getParentAcl();
         }
@@ -873,7 +873,7 @@ QUERY;
 
                     $objectIdentityId = $name === 'classFieldAces' ? null : $ace->getAcl()->getId();
 
-                    $this->connection->executeQuery($this->getInsertAccessControlEntrySql($classId, $objectIdentityId, $field, $i, $sid, $ace->getStrategy(), $ace->getMask(), $ace->isGranting(), $ace->isAuditSuccess(), $ace->isAuditFailure()));
+                    $this->connection->executeUpdate($this->getInsertAccessControlEntrySql($classId, $objectIdentityId, $field, $i, $sid, $ace->getStrategy(), $ace->getMask(), $ace->isGranting(), $ace->isAuditSuccess(), $ace->isAuditFailure()));
                     $aceId = $this->connection->executeQuery($this->getSelectAccessControlEntryIdSql($classId, $objectIdentityId, $field, $i))->fetchColumn();
                     $this->loadedAces[$aceId] = $ace;
 
@@ -909,7 +909,7 @@ QUERY;
                 $ace = $old[$i];
 
                 if (!isset($currentIds[$ace->getId()])) {
-                    $this->connection->executeQuery($this->getDeleteAccessControlEntrySql($ace->getId()));
+                    $this->connection->executeUpdate($this->getDeleteAccessControlEntrySql($ace->getId()));
                     unset($this->loadedAces[$ace->getId()]);
                 }
             }
@@ -947,7 +947,7 @@ QUERY;
 
                 $objectIdentityId = $name === 'classAces' ? null : $ace->getAcl()->getId();
 
-                $this->connection->executeQuery($this->getInsertAccessControlEntrySql($classId, $objectIdentityId, null, $i, $sid, $ace->getStrategy(), $ace->getMask(), $ace->isGranting(), $ace->isAuditSuccess(), $ace->isAuditFailure()));
+                $this->connection->executeUpdate($this->getInsertAccessControlEntrySql($classId, $objectIdentityId, null, $i, $sid, $ace->getStrategy(), $ace->getMask(), $ace->isGranting(), $ace->isAuditSuccess(), $ace->isAuditFailure()));
                 $aceId = $this->connection->executeQuery($this->getSelectAccessControlEntryIdSql($classId, $objectIdentityId, null, $i))->fetchColumn();
                 $this->loadedAces[$aceId] = $ace;
 
@@ -981,7 +981,7 @@ QUERY;
             $ace = $old[$i];
 
             if (!isset($currentIds[$ace->getId()])) {
-                $this->connection->executeQuery($this->getDeleteAccessControlEntrySql($ace->getId()));
+                $this->connection->executeUpdate($this->getDeleteAccessControlEntrySql($ace->getId()));
                 unset($this->loadedAces[$ace->getId()]);
             }
         }
@@ -1029,6 +1029,6 @@ QUERY;
             $sets[] = sprintf('audit_failure = %s', $this->connection->getDatabasePlatform()->convertBooleans($propertyChanges['auditFailure'][1]));
         }
 
-        $this->connection->executeQuery($this->getUpdateAccessControlEntrySql($ace->getId(), $sets));
+        $this->connection->executeUpdate($this->getUpdateAccessControlEntrySql($ace->getId(), $sets));
     }
 }

--- a/Tests/Dbal/MutableAclProviderTest.php
+++ b/Tests/Dbal/MutableAclProviderTest.php
@@ -262,7 +262,7 @@ class MutableAclProviderTest extends \PHPUnit_Framework_TestCase
         ;
         $con
             ->expects($this->never())
-            ->method('executeQuery')
+            ->method('executeUpdate')
         ;
 
         $provider = new MutableAclProvider($con, new PermissionGrantingStrategy(), array());
@@ -477,12 +477,12 @@ class MutableAclProviderTest extends \PHPUnit_Framework_TestCase
                 $aclIds[$name] = $aclId;
 
                 $sql = $this->callMethod($provider, 'getInsertObjectIdentityRelationSql', array($aclId, $aclId));
-                $con->executeQuery($sql);
+                $con->executeUpdate($sql);
 
                 if (isset($aclData['parent_acl'])) {
                     if (isset($aclIds[$aclData['parent_acl']])) {
-                        $con->executeQuery('UPDATE acl_object_identities SET parent_object_identity_id = '.$aclIds[$aclData['parent_acl']].' WHERE id = '.$aclId);
-                        $con->executeQuery($this->callMethod($provider, 'getInsertObjectIdentityRelationSql', array($aclId, $aclIds[$aclData['parent_acl']])));
+                        $con->executeUpdate('UPDATE acl_object_identities SET parent_object_identity_id = '.$aclIds[$aclData['parent_acl']].' WHERE id = '.$aclId);
+                        $con->executeUpdate($this->callMethod($provider, 'getInsertObjectIdentityRelationSql', array($aclId, $aclIds[$aclData['parent_acl']])));
                     } else {
                         $parentAcls[$aclId] = $aclData['parent_acl'];
                     }
@@ -494,8 +494,8 @@ class MutableAclProviderTest extends \PHPUnit_Framework_TestCase
                     throw new \InvalidArgumentException(sprintf('"%s" does not exist.', $name));
                 }
 
-                $con->executeQuery(sprintf('UPDATE acl_object_identities SET parent_object_identity_id = %d WHERE id = %d', $aclIds[$name], $aclId));
-                $con->executeQuery($this->callMethod($provider, 'getInsertObjectIdentityRelationSql', array($aclId, $aclIds[$name])));
+                $con->executeUpdate(sprintf('UPDATE acl_object_identities SET parent_object_identity_id = %d WHERE id = %d', $aclIds[$name], $aclId));
+                $con->executeUpdate($this->callMethod($provider, 'getInsertObjectIdentityRelationSql', array($aclId, $aclIds[$name])));
             }
 
             $con->commit();


### PR DESCRIPTION
I noticed in a project that uses this library that this is using `executeQuery` doctrine method for writing operations, for systems that has a `master` and `slave` databases it results in errors since the slave normally is configured to be read-only and using  `executeQuery` leads to Doctrine trying to use the slave read-only instance to insert, delete or update data, causing errors like the following in Mysql:

```
Error Code: 1290. The MySQL server is running with the –read-only option so it cannot execute this statement
```

This PR changes the `executeQuery` for `executeUpdate` for the writing cases. 