### PR TITLE
override AclProviderInterface::findAcl in MutableAclProviderInterface

### DIFF
--- a/Model/MutableAclProviderInterface.php
+++ b/Model/MutableAclProviderInterface.php
@@ -17,6 +17,8 @@ use Symfony\Component\Security\Acl\Exception\AclAlreadyExistsException;
  * Provides support for creating and storing ACL instances.
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * @method MutableAclInterface findAcl(ObjectIdentityInterface $oid, array $sids = [])
  */
 interface MutableAclProviderInterface extends AclProviderInterface
 {


### PR DESCRIPTION
`AclProviderInterface::findAcl()` returns `AclInterface`
but
`MutableAclProviderInterface::findAcl()` returns `MutableAclInterface`

that's I'm changing this.

Context for this you can see here - https://github.com/sonata-project/SonataAdminBundle/pull/6277#discussion_r469055061