### PR TITLE
Wip59

### DIFF
--- a/Tests/Dbal/MutableAclProviderTest.php
+++ b/Tests/Dbal/MutableAclProviderTest.php
@@ -252,7 +252,7 @@ class MutableAclProviderTest extends \PHPUnit\Framework\TestCase
 
     public function testUpdateDoesNothingWhenThereAreNoChanges()
     {
-        $con = $this->getMock('Doctrine\DBAL\Connection', [], [], '', false);
+        $con = $this->getMockBuilder('Doctrine\DBAL\Connection')->disableOriginalConstructor()->getMock();
         $con
             ->expects($this->never())
             ->method('beginTransaction')

--- a/Tests/Domain/AclTest.php
+++ b/Tests/Domain/AclTest.php
@@ -497,7 +497,7 @@ class AclTest extends \PHPUnit\Framework\TestCase
     {
         $aceProperties = ['aceOrder', 'mask', 'strategy', 'auditSuccess', 'auditFailure'];
 
-        $listener = $this->createMock('Doctrine\Persistence\PropertyChangedListener;');
+        $listener = $this->createMock('Doctrine\Persistence\PropertyChangedListener');
         foreach ($expectedChanges as $index => $property) {
             if (\in_array($property, $aceProperties)) {
                 $class = 'Symfony\Component\Security\Acl\Domain\Entry';

--- a/Tests/Domain/ObjectIdentityTest.php
+++ b/Tests/Domain/ObjectIdentityTest.php
@@ -40,11 +40,14 @@ namespace Symfony\Component\Security\Acl\Tests\Domain
                 ->method('getObjectIdentifier')
                 ->willReturn('getObjectIdentifier()')
             ;
-            $domainObject
-                ->expects($this->never())
-                ->method('getId')
-                ->willReturn('getId()')
-            ;
+// The following commented code makes PHPUnit complain about method
+// "getId" which cannot be configured because it does not exist, has not
+// been specified, is final, or is static
+//            $domainObject
+//                ->expects($this->never())
+//                ->method('getId')
+//                ->willReturn('getId()')
+//            ;
 
             $id = ObjectIdentity::fromDomainObject($domainObject);
             $this->assertEquals('getObjectIdentifier()', $id->getIdentifier());

--- a/Tests/Domain/SecurityIdentityRetrievalStrategyTest.php
+++ b/Tests/Domain/SecurityIdentityRetrievalStrategyTest.php
@@ -122,7 +122,7 @@ class SecurityIdentityRetrievalStrategyTest extends \PHPUnit\Framework\TestCase
 
     protected function getAccount($username, $class)
     {
-        $account = $this->getMock('Symfony\Component\Security\Core\User\UserInterface', [], [], $class);
+        $account = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')->setMockClassName($class)->getMock();
         $account
             ->expects($this->any())
             ->method('getUsername')
@@ -158,7 +158,7 @@ class SecurityIdentityRetrievalStrategyTest extends \PHPUnit\Framework\TestCase
                 ->willReturn($roles);
         }
 
-        $trustResolver = $this->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface', [], ['', '']);
+        $trustResolver = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface')->getMock();
 
         $trustResolver
             ->expects($this->at(0))


### PR DESCRIPTION
Hi

The following change partially addresses #59 by getting rid of the last getMock() calls and warning showed by PHPUnit 8, allowing the testsuite to also run on PHPUnit 9. This PR does not address the risky tests (without assertions) and the last commit probably makes the test useless.

Regards

David