### PR TITLE
Dont allow unserializing classes with a destructor - security-acl

### DIFF
--- a/Domain/FieldEntry.php
+++ b/Domain/FieldEntry.php
@@ -67,6 +67,9 @@ class FieldEntry extends Entry implements FieldEntryInterface
     public function unserialize($serialized)
     {
         list($this->field, $parentStr) = unserialize($serialized);
+        if (!\is_string($parentStr)) {
+            throw new \BadMethodCallException('Cannot serialize '.__CLASS__);
+        }
         parent::unserialize($parentStr);
     }
 }


### PR DESCRIPTION
Prevent destructors with side-effects from being unserialized