### PR TITLE
Fix doctrine/dbal 2.13 incompatibility

### DIFF
--- a/Dbal/AclProvider.php
+++ b/Dbal/AclProvider.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Security\Acl\Dbal;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Driver\Statement;
+use Doctrine\DBAL\Result;
 use Symfony\Component\Security\Acl\Domain\Acl;
 use Symfony\Component\Security\Acl\Domain\Entry;
 use Symfony\Component\Security\Acl\Domain\FieldEntry;
@@ -481,7 +481,7 @@ QUERY;
      *
      * @throws \RuntimeException
      */
-    private function hydrateObjectIdentities(Statement $stmt, array $oidLookup, array $sids)
+    private function hydrateObjectIdentities(Result $stmt, array $oidLookup, array $sids)
     {
         $parentIdToFill = new \SplObjectStorage();
         $acls = $aces = $emptyArray = [];

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "symfony/phpunit-bridge": "^3.4|^4.4|^5.0",
         "doctrine/common": "~2.2",
         "doctrine/persistence": "^1.3.3",
-        "doctrine/dbal": "~2.2",
+        "doctrine/dbal": "^2.13",
         "psr/log": "~1.0"
     },
     "autoload": {
@@ -31,6 +31,9 @@
         "exclude-from-classmap": [
             "/Tests/"
         ]
+    },
+    "conflict": {
+        "doctrine/dbal": "<2.13.0"
     },
     "minimum-stability": "dev",
     "extra": {


### PR DESCRIPTION
Fixes #63 

As [this blogpost](https://www.doctrine-project.org/2021/03/29/dbal-2.13.html) suggests, libraries should update their `doctrine/dbal` dependency to `^2.13`. This PR bumps the `doctrine/dbal` dependency version and fixes the incompatibility