### PR TITLE
Fix branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-main": "3.0-dev"
+            "dev-main": "3.x-dev"
         }
     }
 }


### PR DESCRIPTION
We currently tell composer that the main branch contains version 3.0 although we've already tagged 3.1.x releases. I think it would be wise to use `3.x-dev` as alias instead.