### PR TITLE
Github actions setup and test fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+    [push, pull_request]
+
+jobs:
+    test:
+        name: Test on PHP ${{ matrix.php }}
+        runs-on: ubuntu-latest
+
+        strategy:
+            fail-fast: false
+            matrix:
+                php: ['7.1', '7.2', '7.3', '7.4', '8.0']
+
+        steps:
+            -   uses: actions/checkout@v2
+
+            -   name: Setup PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: ${{ matrix.php }}
+                    coverage: none
+
+            -   name: Determine composer cache directory
+                id: composer-cache
+                run: echo "::set-output name=directory::$(composer config cache-dir)"
+
+            -   name: Cache composer dependencies
+                uses: actions/cache@v2
+                with:
+                    path: ${{ steps.composer-cache.outputs.directory }}
+                    key: ${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}
+                    restore-keys: ${{ matrix.php }}-composer-
+
+            -   name: Install dependencies
+                run: composer update --no-progress --ansi
+
+            -   name: Install simple-phpunit
+                run: vendor/bin/simple-phpunit install
+
+            -   name: Run phpunit
+                run: vendor/bin/simple-phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/
 composer.lock
 phpunit.xml
+.phpunit.result.cache

--- a/Tests/Domain/AclTest.php
+++ b/Tests/Domain/AclTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
 use Symfony\Component\Security\Acl\Domain\PermissionGrantingStrategy;
 use Symfony\Component\Security\Acl\Domain\RoleSecurityIdentity;
 use Symfony\Component\Security\Acl\Domain\UserSecurityIdentity;
+use Doctrine\Persistence\PropertyChangedListener;
 
 class AclTest extends \PHPUnit\Framework\TestCase
 {
@@ -497,7 +498,8 @@ class AclTest extends \PHPUnit\Framework\TestCase
     {
         $aceProperties = ['aceOrder', 'mask', 'strategy', 'auditSuccess', 'auditFailure'];
 
-        $listener = $this->createMock('Doctrine\Persistence\PropertyChangedListener;');
+        $arguments = [];
+        $listener = $this->createMock(PropertyChangedListener::class);
         foreach ($expectedChanges as $index => $property) {
             if (\in_array($property, $aceProperties)) {
                 $class = 'Symfony\Component\Security\Acl\Domain\Entry';
@@ -505,12 +507,12 @@ class AclTest extends \PHPUnit\Framework\TestCase
                 $class = 'Symfony\Component\Security\Acl\Domain\Acl';
             }
 
-            $listener
-                ->expects($this->at($index))
-                ->method('propertyChanged')
-                ->with($this->isInstanceOf($class), $this->equalTo($property))
-            ;
+            $arguments[] = [$this->isInstanceOf($class), $this->equalTo($property)];
         }
+        $listener
+            ->method('propertyChanged')
+            ->withConsecutive(...$arguments)
+        ;
 
         return $listener;
     }

--- a/Tests/Domain/ObjectIdentityTest.php
+++ b/Tests/Domain/ObjectIdentityTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Acl\Tests\Domain
 {
     use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
+    use Symfony\Component\Security\Acl\Model\DomainObjectInterface;
 
     class ObjectIdentityTest extends \PHPUnit\Framework\TestCase
     {
@@ -34,17 +35,17 @@ namespace Symfony\Component\Security\Acl\Tests\Domain
 
         public function testFromDomainObjectPrefersInterfaceOverGetId()
         {
-            $domainObject = $this->createMock('Symfony\Component\Security\Acl\Model\DomainObjectInterface');
-            $domainObject
-                ->expects($this->once())
-                ->method('getObjectIdentifier')
-                ->willReturn('getObjectIdentifier()')
-            ;
-            $domainObject
-                ->expects($this->never())
-                ->method('getId')
-                ->willReturn('getId()')
-            ;
+            $domainObject = new class() implements DomainObjectInterface {
+                public function getObjectIdentifier()
+                {
+                    return 'getObjectIdentifier()';
+                }
+
+                public function getId()
+                {
+                    return 'getId()';
+                }
+            };
 
             $id = ObjectIdentity::fromDomainObject($domainObject);
             $this->assertEquals('getObjectIdentifier()', $id->getIdentifier());

--- a/Tests/Domain/PermissionGrantingStrategyTest.php
+++ b/Tests/Domain/PermissionGrantingStrategyTest.php
@@ -150,11 +150,10 @@ class PermissionGrantingStrategyTest extends \PHPUnit\Framework\TestCase
         $acl->insertObjectAce($sid, $aceMask, 0, true, $maskStrategy);
 
         if (false === $result) {
-            try {
-                $strategy->isGranted($acl, [$requiredMask], [$sid]);
-                $this->fail('The ACE is not supposed to match.');
-            } catch (NoAceFoundException $e) {
-            }
+            $this->expectException(NoAceFoundException::class);
+            $this->expectExceptionMessage('No applicable ACE was found.');
+
+            $strategy->isGranted($acl, [$requiredMask], [$sid]);
         } else {
             $this->assertTrue($strategy->isGranted($acl, [$requiredMask], [$sid]));
         }

--- a/Tests/Domain/RoleSecurityIdentityTest.php
+++ b/Tests/Domain/RoleSecurityIdentityTest.php
@@ -26,6 +26,10 @@ class RoleSecurityIdentityTest extends \PHPUnit\Framework\TestCase
 
     public function testConstructorWithRoleInstance()
     {
+        if (!class_exists(\Symfony\Component\Security\Core\Role\Role::class)) {
+            $this->markTestSkipped();
+        }
+
         $id = new RoleSecurityIdentity(new Role('ROLE_FOO'));
 
         $this->assertEquals('ROLE_FOO', $id->getRole());
@@ -43,11 +47,24 @@ class RoleSecurityIdentityTest extends \PHPUnit\Framework\TestCase
         }
     }
 
+    /**
+     * @group legacy
+     */
+    public function testDeprecatedRoleClassEquals()
+    {
+        if (!class_exists(Role::class)) {
+            $this->markTestSkipped();
+        }
+
+        $id1 = new RoleSecurityIdentity('ROLE_FOO');
+        $id2 = new RoleSecurityIdentity(new Role('ROLE_FOO'));
+        $this->assertTrue($id1->equals($id2));
+    }
+
     public function getCompareData()
     {
         return [
             [new RoleSecurityIdentity('ROLE_FOO'), new RoleSecurityIdentity('ROLE_FOO'), true],
-            [new RoleSecurityIdentity('ROLE_FOO'), new RoleSecurityIdentity(new Role('ROLE_FOO')), true],
             [new RoleSecurityIdentity('ROLE_USER'), new RoleSecurityIdentity('ROLE_FOO'), false],
             [new RoleSecurityIdentity('ROLE_FOO'), new UserSecurityIdentity('ROLE_FOO', 'Foo'), false],
         ];

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "symfony/security-core": "^3.4|^4.4|^5.0"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^3.4|^4.4|^5.0",
+        "symfony/phpunit-bridge": "^5.2",
         "doctrine/common": "~2.2",
         "doctrine/persistence": "^1.3.3",
         "doctrine/dbal": "^2.13",
@@ -35,7 +35,6 @@
     "conflict": {
         "doctrine/dbal": "<2.13.0"
     },
-    "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
             "dev-main": "3.0-dev"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,15 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit backupGlobals="false"
-         backupStaticAttributes="false"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />
@@ -31,4 +26,12 @@
             </exclude>
         </whitelist>
     </filter>
+    <groups>
+        <exclude>
+            <group>benchmark</group>
+        </exclude>
+    </groups>
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+    </listeners>
 </phpunit>


### PR DESCRIPTION
Fixes #59 and closes #61

- This PR adds a github action setup, so that the test suite is actually executed on pr's (and pushes)
- Test fixes as there are quite some failing or risky tests

The github actions result can be viewed here before merge (https://github.com/acrobat/security-acl/actions)

There are 2 risky tests left, but I don't know what to do with them or how to fix them. The test names indicate that there should be an exception thrown but that doesn't happen and there are no asserts performed in those tests.

The tests/fix for an issue were added in https://github.com/symfony/symfony/pull/9485