### PR TITLE
Fix risky tests and deprecation warnings

### DIFF
--- a/Tests/Dbal/MutableAclProviderTest.php
+++ b/Tests/Dbal/MutableAclProviderTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Security\Acl\Tests\Dbal;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Acl\Dbal\AclProvider;
 use Symfony\Component\Security\Acl\Dbal\MutableAclProvider;
 use Symfony\Component\Security\Acl\Dbal\Schema;
@@ -31,7 +32,7 @@ use Symfony\Component\Security\Acl\Model\FieldEntryInterface;
 /**
  * @requires extension pdo_sqlite
  */
-class MutableAclProviderTest extends \PHPUnit\Framework\TestCase
+class MutableAclProviderTest extends TestCase
 {
     protected $con;
 
@@ -383,6 +384,9 @@ class MutableAclProviderTest extends \PHPUnit\Framework\TestCase
         $acl = $provider->findAcl($oid);
         $acl->insertObjectFieldAce($fieldName, $sid3, 4);
         $provider->updateAcl($acl);
+
+        $acls = $provider->findAcl($oid);
+        $this->assertCount(3, $acls->getObjectFieldAces($fieldName));
     }
 
     public function testUpdateAclDeletingObjectFieldAcesThrowsDBConstraintViolations()
@@ -409,6 +413,9 @@ class MutableAclProviderTest extends \PHPUnit\Framework\TestCase
         $acl = $provider->findAcl($oid);
         $acl->insertObjectFieldAce($fieldName, $sid3, 4);
         $provider->updateAcl($acl);
+
+        $acls = $provider->findAcl($oid);
+        $this->assertCount(2, $acls->getObjectFieldAces($fieldName));
     }
 
     public function testUpdateUserSecurityIdentity()

--- a/Tests/Domain/RoleSecurityIdentityTest.php
+++ b/Tests/Domain/RoleSecurityIdentityTest.php
@@ -24,6 +24,9 @@ class RoleSecurityIdentityTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('ROLE_FOO', $id->getRole());
     }
 
+    /**
+     * @group legacy
+     */
     public function testConstructorWithRoleInstance()
     {
         if (!class_exists(\Symfony\Component\Security\Core\Role\Role::class)) {

--- a/Tests/Domain/SecurityIdentityRetrievalStrategyTest.php
+++ b/Tests/Domain/SecurityIdentityRetrievalStrategyTest.php
@@ -11,16 +11,17 @@
 
 namespace Symfony\Component\Security\Acl\Tests\Domain;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Acl\Domain\RoleSecurityIdentity;
 use Symfony\Component\Security\Acl\Domain\SecurityIdentityRetrievalStrategy;
 use Symfony\Component\Security\Acl\Domain\UserSecurityIdentity;
+use Symfony\Component\Security\Core\Authentication\Token\AbstractToken;
 use Symfony\Component\Security\Core\Role\Role;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
-class SecurityIdentityRetrievalStrategyTest extends \PHPUnit\Framework\TestCase
+class SecurityIdentityRetrievalStrategyTest extends TestCase
 {
     /**
      * @dataProvider getSecurityIdentityRetrievalTests
@@ -37,7 +38,7 @@ class SecurityIdentityRetrievalStrategyTest extends \PHPUnit\Framework\TestCase
                 $class = 'MyCustomTokenImpl';
             }
 
-            $token = $this->getMockBuilder(TokenInterface::class)
+            $token = $this->getMockBuilder(AbstractToken::class)
                 ->setMockClassName($class)
                 ->getMock();
         }


### PR DESCRIPTION
This PR fixes the two risky tests and should (hopefully) give us a green CI.

The two tests in question were added in symfony/symfony#9485. As far as I read the PR, the tests should ensure that no exception is thrown. But because they don't assert anything, modern PHPUnit versions would flag the tests as risky. I avoid this issue by bumping the asserion count at the end of each test.