### PR TITLE
Add tests for lowest dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,43 +1,43 @@
 name: CI
 
 on:
-    [push, pull_request]
+    pull_request:
+    push:
+        branches: [main]
 
 jobs:
     test:
-        name: Test on PHP ${{ matrix.php }}
+        name: 'Test ${{ matrix.deps }} on PHP ${{ matrix.php }}'
         runs-on: ubuntu-latest
 
         strategy:
             fail-fast: false
             matrix:
-                php: ['7.1', '7.2', '7.3', '7.4', '8.0']
+                php: ['7.1.3', '7.2', '7.3', '7.4', '8.0']
+                include:
+                    - php: '7.4'
+                      deps: lowest
+                      deprecations: max[self]=0
 
         steps:
-            -   uses: actions/checkout@v2
+            - name: Checkout code
+              uses: actions/checkout@v2
 
-            -   name: Setup PHP
-                uses: shivammathur/setup-php@v2
-                with:
-                    php-version: ${{ matrix.php }}
-                    coverage: none
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: '${{ matrix.php }}'
+                  coverage: none
 
-            -   name: Determine composer cache directory
-                id: composer-cache
-                run: echo "::set-output name=directory::$(composer config cache-dir)"
+            - name: Composer install
+              uses: ramsey/composer-install@v1
+              with:
+                  dependency-versions: '${{ matrix.deps }}'
 
-            -   name: Cache composer dependencies
-                uses: actions/cache@v2
-                with:
-                    path: ${{ steps.composer-cache.outputs.directory }}
-                    key: ${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}
-                    restore-keys: ${{ matrix.php }}-composer-
+            - name: Install PHPUnit
+              run: vendor/bin/simple-phpunit install
 
-            -   name: Install dependencies
-                run: composer update --no-progress --ansi
-
-            -   name: Install simple-phpunit
-                run: vendor/bin/simple-phpunit install
-
-            -   name: Run phpunit
-                run: vendor/bin/simple-phpunit
+            - name: Run tests
+              run: vendor/bin/simple-phpunit
+              env:
+                  SYMFONY_DEPRECATIONS_HELPER: '${{ matrix.deprecations }}'


### PR DESCRIPTION
Updates the GitHub actions config to be somewhat in sync with e.g. the MakerBundle. Besides that, it also adds a job to test lowest dependencies (which most Symfony packages also do).