### PR TITLE
Add an AclCache implementation supporting a PSR-6 cache pool

### DIFF
--- a/Domain/AclCacheTrait.php
+++ b/Domain/AclCacheTrait.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Acl\Domain;
+
+use Symfony\Component\Security\Acl\Model\AclInterface;
+use Symfony\Component\Security\Acl\Model\ObjectIdentityInterface;
+
+/**
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * @internal
+ */
+trait AclCacheTrait
+{
+    private $prefix;
+    private $permissionGrantingStrategy;
+
+    /**
+     * Unserializes the ACL.
+     */
+    private function unserializeAcl(string $serialized): ?AclInterface
+    {
+        $acl = unserialize($serialized);
+
+        if (null !== $parentId = $acl->getParentAcl()) {
+            $parentAcl = $this->getFromCacheById($parentId);
+
+            if (null === $parentAcl) {
+                return null;
+            }
+
+            $acl->setParentAcl($parentAcl);
+        }
+
+        $reflectionProperty = new \ReflectionProperty($acl, 'permissionGrantingStrategy');
+        $reflectionProperty->setAccessible(true);
+        $reflectionProperty->setValue($acl, $this->permissionGrantingStrategy);
+        $reflectionProperty->setAccessible(false);
+
+        $aceAclProperty = new \ReflectionProperty('Symfony\Component\Security\Acl\Domain\Entry', 'acl');
+        $aceAclProperty->setAccessible(true);
+
+        foreach ($acl->getObjectAces() as $ace) {
+            $aceAclProperty->setValue($ace, $acl);
+        }
+        foreach ($acl->getClassAces() as $ace) {
+            $aceAclProperty->setValue($ace, $acl);
+        }
+
+        $aceClassFieldProperty = new \ReflectionProperty($acl, 'classFieldAces');
+        $aceClassFieldProperty->setAccessible(true);
+        foreach ($aceClassFieldProperty->getValue($acl) as $aces) {
+            foreach ($aces as $ace) {
+                $aceAclProperty->setValue($ace, $acl);
+            }
+        }
+        $aceClassFieldProperty->setAccessible(false);
+
+        $aceObjectFieldProperty = new \ReflectionProperty($acl, 'objectFieldAces');
+        $aceObjectFieldProperty->setAccessible(true);
+        foreach ($aceObjectFieldProperty->getValue($acl) as $aces) {
+            foreach ($aces as $ace) {
+                $aceAclProperty->setValue($ace, $acl);
+            }
+        }
+        $aceObjectFieldProperty->setAccessible(false);
+
+        $aceAclProperty->setAccessible(false);
+
+        return $acl;
+    }
+
+    /**
+     * Returns the key for the object identity.
+     */
+    private function getDataKeyByIdentity(ObjectIdentityInterface $oid): string
+    {
+        return $this->prefix.md5($oid->getType()).sha1($oid->getType())
+               .'_'.md5($oid->getIdentifier()).sha1($oid->getIdentifier());
+    }
+
+    /**
+     * Returns the alias key for the object identity key.
+     */
+    private function getAliasKeyForIdentity(string $aclId): string
+    {
+        return $this->prefix.$aclId;
+    }
+}

--- a/Domain/DoctrineAclCache.php
+++ b/Domain/DoctrineAclCache.php
@@ -25,11 +25,11 @@ use Symfony\Component\Security\Acl\Model\PermissionGrantingStrategyInterface;
  */
 class DoctrineAclCache implements AclCacheInterface
 {
+    use AclCacheTrait;
+
     const PREFIX = 'sf2_acl_';
 
     private $cache;
-    private $prefix;
-    private $permissionGrantingStrategy;
 
     /**
      * Constructor.
@@ -139,87 +139,5 @@ class DoctrineAclCache implements AclCacheInterface
         $key = $this->getDataKeyByIdentity($acl->getObjectIdentity());
         $this->cache->save($key, serialize($acl));
         $this->cache->save($this->getAliasKeyForIdentity($acl->getId()), $key);
-    }
-
-    /**
-     * Unserializes the ACL.
-     *
-     * @param string $serialized
-     *
-     * @return AclInterface
-     */
-    private function unserializeAcl($serialized)
-    {
-        $acl = unserialize($serialized);
-
-        if (null !== $parentId = $acl->getParentAcl()) {
-            $parentAcl = $this->getFromCacheById($parentId);
-
-            if (null === $parentAcl) {
-                return;
-            }
-
-            $acl->setParentAcl($parentAcl);
-        }
-
-        $reflectionProperty = new \ReflectionProperty($acl, 'permissionGrantingStrategy');
-        $reflectionProperty->setAccessible(true);
-        $reflectionProperty->setValue($acl, $this->permissionGrantingStrategy);
-        $reflectionProperty->setAccessible(false);
-
-        $aceAclProperty = new \ReflectionProperty('Symfony\Component\Security\Acl\Domain\Entry', 'acl');
-        $aceAclProperty->setAccessible(true);
-
-        foreach ($acl->getObjectAces() as $ace) {
-            $aceAclProperty->setValue($ace, $acl);
-        }
-        foreach ($acl->getClassAces() as $ace) {
-            $aceAclProperty->setValue($ace, $acl);
-        }
-
-        $aceClassFieldProperty = new \ReflectionProperty($acl, 'classFieldAces');
-        $aceClassFieldProperty->setAccessible(true);
-        foreach ($aceClassFieldProperty->getValue($acl) as $aces) {
-            foreach ($aces as $ace) {
-                $aceAclProperty->setValue($ace, $acl);
-            }
-        }
-        $aceClassFieldProperty->setAccessible(false);
-
-        $aceObjectFieldProperty = new \ReflectionProperty($acl, 'objectFieldAces');
-        $aceObjectFieldProperty->setAccessible(true);
-        foreach ($aceObjectFieldProperty->getValue($acl) as $aces) {
-            foreach ($aces as $ace) {
-                $aceAclProperty->setValue($ace, $acl);
-            }
-        }
-        $aceObjectFieldProperty->setAccessible(false);
-
-        $aceAclProperty->setAccessible(false);
-
-        return $acl;
-    }
-
-    /**
-     * Returns the key for the object identity.
-     *
-     * @return string
-     */
-    private function getDataKeyByIdentity(ObjectIdentityInterface $oid)
-    {
-        return $this->prefix.md5($oid->getType()).sha1($oid->getType())
-               .'_'.md5($oid->getIdentifier()).sha1($oid->getIdentifier());
-    }
-
-    /**
-     * Returns the alias key for the object identity key.
-     *
-     * @param string $aclId
-     *
-     * @return string
-     */
-    private function getAliasKeyForIdentity($aclId)
-    {
-        return $this->prefix.$aclId;
     }
 }

--- a/Domain/PsrAclCache.php
+++ b/Domain/PsrAclCache.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Acl\Domain;
+
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Security\Acl\Model\AclCacheInterface;
+use Symfony\Component\Security\Acl\Model\AclInterface;
+use Symfony\Component\Security\Acl\Model\ObjectIdentityInterface;
+use Symfony\Component\Security\Acl\Model\PermissionGrantingStrategyInterface;
+
+/**
+ * This class is a wrapper around a PSR-6 cache implementation.
+ *
+ * @author Michael Babker <michael.babker@gmail.com>
+ */
+class PsrAclCache implements AclCacheInterface
+{
+    use AclCacheTrait;
+
+    const PREFIX = 'sf_acl_';
+
+    private $cache;
+
+    /**
+     * @throws \InvalidArgumentException When $prefix is empty
+     */
+    public function __construct(CacheItemPoolInterface $cache, PermissionGrantingStrategyInterface $permissionGrantingStrategy, string $prefix = self::PREFIX)
+    {
+        if (0 === \strlen($prefix)) {
+            throw new \InvalidArgumentException('$prefix cannot be empty.');
+        }
+
+        $this->cache = $cache;
+        $this->permissionGrantingStrategy = $permissionGrantingStrategy;
+        $this->prefix = $prefix;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function clearCache(): void
+    {
+        $this->cache->clear();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function evictFromCacheById($aclId): void
+    {
+        $lookupKey = $this->getAliasKeyForIdentity($aclId);
+        $cacheItem = $this->cache->getItem($lookupKey);
+        if (!$cacheItem->isHit()) {
+            return;
+        }
+
+        $this->cache->deleteItems([$cacheItem->get(), $lookupKey]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function evictFromCacheByIdentity(ObjectIdentityInterface $oid): void
+    {
+        $this->cache->deleteItem($this->getDataKeyByIdentity($oid));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFromCacheById($aclId): ?AclInterface
+    {
+        $lookupKey = $this->getAliasKeyForIdentity($aclId);
+        $lookupKeyItem = $this->cache->getItem($lookupKey);
+        if (!$lookupKeyItem->isHit()) {
+            return null;
+        }
+
+        $key = $lookupKeyItem->get();
+        $keyItem = $this->cache->getItem($key);
+        if (!$keyItem->isHit()) {
+            $this->cache->deleteItem($lookupKey);
+
+            return null;
+        }
+
+        return $this->unserializeAcl($keyItem->get());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFromCacheByIdentity(ObjectIdentityInterface $oid): ?AclInterface
+    {
+        $key = $this->getDataKeyByIdentity($oid);
+        $cacheItem = $this->cache->getItem($key);
+        if (!$cacheItem->isHit()) {
+            return null;
+        }
+
+        return $this->unserializeAcl($cacheItem->get());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function putInCache(AclInterface $acl): void
+    {
+        if (null === $acl->getId()) {
+            throw new \InvalidArgumentException('Transient ACLs cannot be cached.');
+        }
+
+        if (null !== $parentAcl = $acl->getParentAcl()) {
+            $this->putInCache($parentAcl);
+        }
+
+        $key = $this->getDataKeyByIdentity($acl->getObjectIdentity());
+        $objectIdentityItem = $this->cache->getItem($key);
+        $objectIdentityItem->set(serialize($acl));
+
+        $this->cache->saveDeferred($objectIdentityItem);
+
+        $aliasKey = $this->getAliasKeyForIdentity($acl->getId());
+        $aliasItem = $this->cache->getItem($aliasKey);
+        $aliasItem->set($key);
+
+        $this->cache->saveDeferred($aliasItem);
+
+        $this->cache->commit();
+    }
+}

--- a/Tests/Domain/PsrAclCacheTest.php
+++ b/Tests/Domain/PsrAclCacheTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Acl\Tests\Domain;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Security\Acl\Domain\Acl;
+use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
+use Symfony\Component\Security\Acl\Domain\PermissionGrantingStrategy;
+use Symfony\Component\Security\Acl\Domain\PsrAclCache;
+use Symfony\Component\Security\Acl\Domain\UserSecurityIdentity;
+
+class PsrAclCacheTest extends TestCase
+{
+    protected $permissionGrantingStrategy;
+
+    public function testConstructorDoesNotAcceptEmptyPrefix()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new PsrAclCache(new ArrayAdapter(), $this->getPermissionGrantingStrategy(), '');
+    }
+
+    public function test()
+    {
+        $cache = $this->getCache();
+
+        $aclWithParent = $this->getAcl(1);
+        $acl = $this->getAcl();
+
+        $cache->putInCache($aclWithParent);
+        $cache->putInCache($acl);
+
+        $cachedAcl = $cache->getFromCacheByIdentity($acl->getObjectIdentity());
+        $this->assertEquals($acl->getId(), $cachedAcl->getId());
+        $this->assertNull($acl->getParentAcl());
+
+        $cachedAclWithParent = $cache->getFromCacheByIdentity($aclWithParent->getObjectIdentity());
+        $this->assertEquals($aclWithParent->getId(), $cachedAclWithParent->getId());
+        $this->assertNotNull($cachedParentAcl = $cachedAclWithParent->getParentAcl());
+        $this->assertEquals($aclWithParent->getParentAcl()->getId(), $cachedParentAcl->getId());
+    }
+
+    protected function getAcl($depth = 0)
+    {
+        static $id = 1;
+
+        $acl = new Acl($id, new ObjectIdentity($id, 'foo'), $this->getPermissionGrantingStrategy(), [], $depth > 0);
+
+        // insert some ACEs
+        $sid = new UserSecurityIdentity('johannes', 'Foo');
+        $acl->insertClassAce($sid, 1);
+        $acl->insertClassFieldAce('foo', $sid, 1);
+        $acl->insertObjectAce($sid, 1);
+        $acl->insertObjectFieldAce('foo', $sid, 1);
+        ++$id;
+
+        if ($depth > 0) {
+            $acl->setParentAcl($this->getAcl($depth - 1));
+        }
+
+        return $acl;
+    }
+
+    protected function getPermissionGrantingStrategy()
+    {
+        if (null === $this->permissionGrantingStrategy) {
+            $this->permissionGrantingStrategy = new PermissionGrantingStrategy();
+        }
+
+        return $this->permissionGrantingStrategy;
+    }
+
+    protected function getCache($cacheDriver = null, $prefix = PsrAclCache::PREFIX)
+    {
+        if (null === $cacheDriver) {
+            $cacheDriver = new ArrayAdapter();
+        }
+
+        return new PsrAclCache($cacheDriver, $this->getPermissionGrantingStrategy(), $prefix);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,10 @@
         "symfony/security-core": "^3.4|^4.4|^5.0"
     },
     "require-dev": {
+        "symfony/cache": "^3.4|^4.4|^5.0",
         "symfony/finder": "^3.4|^4.4|^5.0",
         "symfony/phpunit-bridge": "^5.2",
+        "doctrine/cache": "^1.6",
         "doctrine/common": "^2.2|^3",
         "doctrine/persistence": "^1.3.3|^2",
         "doctrine/dbal": "^2.13.1|^3.1",


### PR DESCRIPTION
With [`doctrine/cache` being sunsetted](https://github.com/doctrine/cache/issues/354), the component should provide a cache implementation that doesn't rely on an effectively deprecated package.  This PR adds a cache implementation supporting any PSR-6 cache pool which can be used as a replacement.

Closes #76