### PR TITLE
Fix return types on AclCacheInterface

### DIFF
--- a/Model/AclCacheInterface.php
+++ b/Model/AclCacheInterface.php
@@ -37,14 +37,14 @@ interface AclCacheInterface
      *
      * @param int $primaryKey
      *
-     * @return AclInterface
+     * @return AclInterface|null
      */
     public function getFromCacheById($primaryKey);
 
     /**
      * Retrieves an ACL for the given object identity from the cache.
      *
-     * @return AclInterface
+     * @return AclInterface|null
      */
     public function getFromCacheByIdentity(ObjectIdentityInterface $oid);
 


### PR DESCRIPTION
Looking at the implementation, it appears to be expected that these methods return `null` on cache misses.