### PR TITLE
Drop support for Symfony 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: ['7.1.3', '7.2', '7.3', '7.4', '8.0']
+                php: ['7.2.5', '7.3', '7.4', '8.0']
                 include:
                     - php: '7.4'
                       deps: lowest

--- a/Domain/RoleSecurityIdentity.php
+++ b/Domain/RoleSecurityIdentity.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Security\Acl\Domain;
 
 use Symfony\Component\Security\Acl\Model\SecurityIdentityInterface;
-use Symfony\Component\Security\Core\Role\Role;
 
 /**
  * A SecurityIdentity implementation for roles.
@@ -23,17 +22,8 @@ final class RoleSecurityIdentity implements SecurityIdentityInterface
 {
     private $role;
 
-    /**
-     * Constructor.
-     *
-     * @param mixed $role a Role instance, or its string representation
-     */
-    public function __construct($role)
+    public function __construct(string $role)
     {
-        if ($role instanceof Role) {
-            $role = $role->getRole();
-        }
-
         $this->role = $role;
     }
 

--- a/Domain/SecurityIdentityRetrievalStrategy.php
+++ b/Domain/SecurityIdentityRetrievalStrategy.php
@@ -16,7 +16,6 @@ use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverIn
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
-use Symfony\Component\Security\Core\Role\Role;
 use Symfony\Component\Security\Core\Role\RoleHierarchyInterface;
 
 /**
@@ -55,15 +54,8 @@ class SecurityIdentityRetrievalStrategy implements SecurityIdentityRetrievalStra
         }
 
         // add all reachable roles
-        if (method_exists($this->roleHierarchy, 'getReachableRoleNames')) {
-            foreach ($this->roleHierarchy->getReachableRoleNames($this->getRoleNames($token)) as $role) {
-                $sids[] = new RoleSecurityIdentity($role);
-            }
-        } else {
-            // Symfony < 4.3 BC layer
-            foreach ($this->roleHierarchy->getReachableRoles($token->getRoles()) as $role) {
-                $sids[] = new RoleSecurityIdentity($role);
-            }
+        foreach ($this->roleHierarchy->getReachableRoleNames($token->getRoleNames()) as $role) {
+            $sids[] = new RoleSecurityIdentity($role);
         }
 
         // add built-in special roles
@@ -79,17 +71,5 @@ class SecurityIdentityRetrievalStrategy implements SecurityIdentityRetrievalStra
         }
 
         return $sids;
-    }
-
-    private function getRoleNames(TokenInterface $token)
-    {
-        if (method_exists($token, 'getRoleNames')) {
-            return $token->getRoleNames();
-        }
-
-        // Symfony < 4.3 BC layer
-        return array_map(function (Role $role) {
-            return $role->getRole();
-        }, $token->getRoles());
     }
 }

--- a/Tests/Domain/RoleSecurityIdentityTest.php
+++ b/Tests/Domain/RoleSecurityIdentityTest.php
@@ -11,11 +11,12 @@
 
 namespace Symfony\Component\Security\Acl\Tests\Domain;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Acl\Domain\RoleSecurityIdentity;
 use Symfony\Component\Security\Acl\Domain\UserSecurityIdentity;
-use Symfony\Component\Security\Core\Role\Role;
+use Symfony\Component\Security\Acl\Model\SecurityIdentityInterface;
 
-class RoleSecurityIdentityTest extends \PHPUnit\Framework\TestCase
+class RoleSecurityIdentityTest extends TestCase
 {
     public function testConstructor()
     {
@@ -25,23 +26,9 @@ class RoleSecurityIdentityTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @group legacy
-     */
-    public function testConstructorWithRoleInstance()
-    {
-        if (!class_exists(\Symfony\Component\Security\Core\Role\Role::class)) {
-            $this->markTestSkipped();
-        }
-
-        $id = new RoleSecurityIdentity(new Role('ROLE_FOO'));
-
-        $this->assertEquals('ROLE_FOO', $id->getRole());
-    }
-
-    /**
      * @dataProvider getCompareData
      */
-    public function testEquals($id1, $id2, $equal)
+    public function testEquals(RoleSecurityIdentity $id1, SecurityIdentityInterface $id2, bool $equal)
     {
         if ($equal) {
             $this->assertTrue($id1->equals($id2));
@@ -50,21 +37,7 @@ class RoleSecurityIdentityTest extends \PHPUnit\Framework\TestCase
         }
     }
 
-    /**
-     * @group legacy
-     */
-    public function testDeprecatedRoleClassEquals()
-    {
-        if (!class_exists(Role::class)) {
-            $this->markTestSkipped();
-        }
-
-        $id1 = new RoleSecurityIdentity('ROLE_FOO');
-        $id2 = new RoleSecurityIdentity(new Role('ROLE_FOO'));
-        $this->assertTrue($id1->equals($id2));
-    }
-
-    public function getCompareData()
+    public function getCompareData(): array
     {
         return [
             [new RoleSecurityIdentity('ROLE_FOO'), new RoleSecurityIdentity('ROLE_FOO'), true],

--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
         }
     ],
     "require": {
-        "php": ">=7.1.3",
-        "symfony/security-core": "^3.4|^4.4|^5.0"
+        "php": ">=7.2.5",
+        "symfony/security-core": "^4.4|^5.0"
     },
     "require-dev": {
-        "symfony/cache": "^3.4|^4.4|^5.0",
-        "symfony/finder": "^3.4|^4.4|^5.0",
+        "symfony/cache": "^4.4|^5.0",
+        "symfony/finder": "^4.4|^5.0",
         "symfony/phpunit-bridge": "^5.2",
         "doctrine/cache": "^1.6",
         "doctrine/common": "^2.2|^3",


### PR DESCRIPTION
This PR proposes to perform the version bumps that we've done on https://github.com/symfony/acl-bundle already:
* Symfony 4.4
* PHP 7.2

Symfony 3 is EOL and we don't develop features for PHP 7.1 anymore. This would also allow us to drop some compatibility code as well as modernize methods with property type declarations.