### PR TITLE
Improve findAcl phpdoc

### DIFF
--- a/Model/AclProviderInterface.php
+++ b/Model/AclProviderInterface.php
@@ -46,7 +46,7 @@ interface AclProviderInterface
      * @param ObjectIdentityInterface[]   $oids an array of ObjectIdentityInterface implementations
      * @param SecurityIdentityInterface[] $sids an array of SecurityIdentityInterface implementations
      *
-     * @return \SplObjectStorage mapping the passed object identities to ACLs
+     * @return \SplObjectStorage<ObjectIdentityInterface, AclInterface> mapping the passed object identities to ACLs
      *
      * @throws AclNotFoundException when we cannot find an ACL for all identities
      */

--- a/Model/MutableAclProviderInterface.php
+++ b/Model/MutableAclProviderInterface.php
@@ -21,6 +21,20 @@ use Symfony\Component\Security\Acl\Exception\AclAlreadyExistsException;
 interface MutableAclProviderInterface extends AclProviderInterface
 {
     /**
+     * {@inheritdoc}
+     *
+     * @return MutableAclInterface
+     */
+    public function findAcl(ObjectIdentityInterface $oid, array $sids = []);
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return \SplObjectStorage<ObjectIdentityInterface, MutableAclInterface> mapping the passed object identities to ACLs
+     */
+    public function findAcls(array $oids, array $sids = []);
+
+    /**
      * Creates a new ACL for the given object identity.
      *
      * @throws AclAlreadyExistsException when there already is an ACL for the given


### PR DESCRIPTION
Hi @nicolas-grekas 

I assume `MutableAclProviderInterface::findAcl` is supposed to return `MutableAclInterface` (and same for findAcls) but currently since `MutableAclProviderInterface` extends `AclProviderInterface`, it inherit of the same phpdoc for those method so return only an `AclInterface`.

This would avoid phpstan-symfony (and psalm-symfony) plugin to introduce some stub about those file.

Related phpstan issue: https://github.com/phpstan/phpstan-symfony/issues/183
Related psalm issue: https://github.com/psalm/psalm-plugin-symfony/issues/189