### PR TITLE
Improve AclInterface phpdoc

### DIFF
--- a/Model/AclInterface.php
+++ b/Model/AclInterface.php
@@ -28,7 +28,7 @@ interface AclInterface extends \Serializable
     /**
      * Returns all class-based ACEs associated with this ACL.
      *
-     * @return array
+     * @return array<int, EntryInterface>
      */
     public function getClassAces();
 
@@ -37,14 +37,14 @@ interface AclInterface extends \Serializable
      *
      * @param string $field
      *
-     * @return array
+     * @return array<int, EntryInterface>
      */
     public function getClassFieldAces($field);
 
     /**
      * Returns all object-based ACEs associated with this ACL.
      *
-     * @return array
+     * @return array<int, EntryInterface>
      */
     public function getObjectAces();
 
@@ -53,7 +53,7 @@ interface AclInterface extends \Serializable
      *
      * @param string $field
      *
-     * @return array
+     * @return array<int, EntryInterface>
      */
     public function getObjectFieldAces($field);
 


### PR DESCRIPTION
HI @derrabus @wouterj, 

The following code (really simplified)
```
foreach ($acl->getObjectAces() as $currentIndex => $currentAce) {
    $acl->updateObjectAce($currentIndex, $mask);
 }
```
is reporting an issue with static analysis because, `updateObjectAce` expect an int, but the index of `getObjectAces` can be int|string. So I updated the phpdoc to restrict it to `int`.