### PR TITLE
Add parameter types to AclInterface

### DIFF
--- a/Domain/Acl.php
+++ b/Domain/Acl.php
@@ -113,7 +113,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * {@inheritdoc}
      */
-    public function getClassFieldAces($field)
+    public function getClassFieldAces(string $field)
     {
         return $this->classFieldAces[$field] ?? [];
     }
@@ -129,7 +129,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * {@inheritdoc}
      */
-    public function getObjectFieldAces($field)
+    public function getObjectFieldAces(string $field)
     {
         return $this->objectFieldAces[$field] ?? [];
     }
@@ -201,7 +201,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * {@inheritdoc}
      */
-    public function isFieldGranted($field, array $masks, array $securityIdentities, $administrativeMode = false)
+    public function isFieldGranted(string $field, array $masks, array $securityIdentities, bool $administrativeMode = false)
     {
         return $this->permissionGrantingStrategy->isFieldGranted($this, $field, $masks, $securityIdentities, $administrativeMode);
     }
@@ -209,7 +209,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * {@inheritdoc}
      */
-    public function isGranted(array $masks, array $securityIdentities, $administrativeMode = false)
+    public function isGranted(array $masks, array $securityIdentities, bool $administrativeMode = false)
     {
         return $this->permissionGrantingStrategy->isGranted($this, $masks, $securityIdentities, $administrativeMode);
     }

--- a/Model/AclInterface.php
+++ b/Model/AclInterface.php
@@ -35,11 +35,9 @@ interface AclInterface extends \Serializable
     /**
      * Returns all class-field-based ACEs associated with this ACL.
      *
-     * @param string $field
-     *
      * @return array<int, EntryInterface>
      */
-    public function getClassFieldAces($field);
+    public function getClassFieldAces(string $field);
 
     /**
      * Returns all object-based ACEs associated with this ACL.
@@ -51,11 +49,9 @@ interface AclInterface extends \Serializable
     /**
      * Returns all object-field-based ACEs associated with this ACL.
      *
-     * @param string $field
-     *
      * @return array<int, EntryInterface>
      */
-    public function getObjectFieldAces($field);
+    public function getObjectFieldAces(string $field);
 
     /**
      * Returns the object identity associated with this ACL.
@@ -81,28 +77,23 @@ interface AclInterface extends \Serializable
     /**
      * Determines whether field access is granted.
      *
-     * @param string $field
-     * @param bool   $administrativeMode
-     *
      * @return bool
      */
-    public function isFieldGranted($field, array $masks, array $securityIdentities, $administrativeMode = false);
+    public function isFieldGranted(string $field, array $masks, array $securityIdentities, bool $administrativeMode = false);
 
     /**
      * Determines whether access is granted.
-     *
-     * @param bool $administrativeMode
      *
      * @throws NoAceFoundException when no ACE was applicable for this request
      *
      * @return bool
      */
-    public function isGranted(array $masks, array $securityIdentities, $administrativeMode = false);
+    public function isGranted(array $masks, array $securityIdentities, bool $administrativeMode = false);
 
     /**
      * Whether the ACL has loaded ACEs for all of the passed security identities.
      *
-     * @param mixed $securityIdentities an implementation of SecurityIdentityInterface, or an array thereof
+     * @param SecurityIdentityInterface|SecurityIdentityInterface[] $securityIdentities
      *
      * @return bool
      */


### PR DESCRIPTION
~~Let's see if the Psalm check is working.~~ Seems to work.

This PR turns `@parameter` annotations of `AclInterface` into real parameter types where possible on PHP 7.2.