### PR TITLE
Declare incompatibility with `symfony/security-core` 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=7.2.5",
-        "symfony/security-core": "^4.4|^5.0|^6.0"
+        "symfony/security-core": "^4.4|^5.0"
     },
     "require-dev": {
         "symfony/cache": "^4.4|^5.0|^6.0",


### PR DESCRIPTION
On the 6.0 branch, `symfony/security-core` has added return type declarations to the `VoterInterface`. Our implementation `AclVoter` is incompatible which is why our high-deps CI job is currently failing.

Since this incompatibility is not trivial to fix in a backwards-compatible manner, I propose to remove the 6.0 branch from the list of compatible versions.