### PR TITLE
Fix symfony 5.3 security incompatiblity

### DIFF
--- a/Domain/SecurityIdentityRetrievalStrategy.php
+++ b/Domain/SecurityIdentityRetrievalStrategy.php
@@ -78,7 +78,7 @@ class SecurityIdentityRetrievalStrategy implements SecurityIdentityRetrievalStra
 
     private function isNotAuthenticated(TokenInterface $token): bool
     {
-        if (\defined('\Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter::PUBLIC_ACCESS')) {
+        if (method_exists($this->authenticationTrustResolver, 'isAuthenticated')) {
             return !$this->authenticationTrustResolver->isAuthenticated($token);
         }
 


### PR DESCRIPTION
Follow up of #100 

The `AuthenticationTrustResolverInterface::isAuthenticated` method was only added in symfony 5.4 but the `AuthenticatedVoter::PUBLIC_ACCESS` constant was already available in symfony 5.3, this causes an error when using security-acl 3.3.0 with symfony 5.3.x

https://github.com/symfony/security-acl/blob/04d6fadd671d72ff322e20840e510030753e008a/Domain/SecurityIdentityRetrievalStrategy.php#L81-L83

The first commit actually refactors the test case because even when executing the tests on symfony 5.3 they still pass as we mocked that class/method. I've also changed some things in the github ci workflow because I wasn't able to get symfony 5.3 dependencies with the` ramsey/composer-install` packages (lowest = install, highest = update but this would cause dev packages in this setup), so I'm not sure if this is the desired setup. Let me know if I need the change anything.

The second commit actually fixes the problem (the first commit shows a failing test on symfony 5.3 first)