### PR TITLE
Fix compatibility with DBAL 4.x

### DIFF
--- a/Dbal/Schema.php
+++ b/Dbal/Schema.php
@@ -94,9 +94,9 @@ final class Schema extends BaseSchema
         $table->addUniqueIndex(['class_id', 'object_identity_id', 'field_name', 'ace_order']);
         $table->addIndex(['class_id', 'object_identity_id', 'security_identity_id']);
 
-        $table->addForeignKeyConstraint($this->getTable($this->options['class_table_name']), ['class_id'], ['id'], ['onDelete' => 'CASCADE', 'onUpdate' => 'CASCADE']);
-        $table->addForeignKeyConstraint($this->getTable($this->options['oid_table_name']), ['object_identity_id'], ['id'], ['onDelete' => 'CASCADE', 'onUpdate' => 'CASCADE']);
-        $table->addForeignKeyConstraint($this->getTable($this->options['sid_table_name']), ['security_identity_id'], ['id'], ['onDelete' => 'CASCADE', 'onUpdate' => 'CASCADE']);
+        $table->addForeignKeyConstraint($this->getTable($this->options['class_table_name'])->getName(), ['class_id'], ['id'], ['onDelete' => 'CASCADE', 'onUpdate' => 'CASCADE']);
+        $table->addForeignKeyConstraint($this->getTable($this->options['oid_table_name'])->getName(), ['object_identity_id'], ['id'], ['onDelete' => 'CASCADE', 'onUpdate' => 'CASCADE']);
+        $table->addForeignKeyConstraint($this->getTable($this->options['sid_table_name'])->getName(), ['security_identity_id'], ['id'], ['onDelete' => 'CASCADE', 'onUpdate' => 'CASCADE']);
     }
 
     /**
@@ -116,7 +116,7 @@ final class Schema extends BaseSchema
         $table->addUniqueIndex(['object_identifier', 'class_id']);
         $table->addIndex(['parent_object_identity_id']);
 
-        $table->addForeignKeyConstraint($table, ['parent_object_identity_id'], ['id']);
+        $table->addForeignKeyConstraint($table->getName(), ['parent_object_identity_id'], ['id']);
     }
 
     /**
@@ -137,8 +137,8 @@ final class Schema extends BaseSchema
             // MS SQL Server does not support recursive cascading
             $action = 'NO ACTION';
         }
-        $table->addForeignKeyConstraint($oidTable, ['object_identity_id'], ['id'], ['onDelete' => $action, 'onUpdate' => $action]);
-        $table->addForeignKeyConstraint($oidTable, ['ancestor_id'], ['id'], ['onDelete' => $action, 'onUpdate' => $action]);
+        $table->addForeignKeyConstraint($oidTable->getName(), ['object_identity_id'], ['id'], ['onDelete' => $action, 'onUpdate' => $action]);
+        $table->addForeignKeyConstraint($oidTable->getName(), ['ancestor_id'], ['id'], ['onDelete' => $action, 'onUpdate' => $action]);
     }
 
     /**

--- a/Tests/Dbal/MutableAclProviderTest.php
+++ b/Tests/Dbal/MutableAclProviderTest.php
@@ -263,7 +263,7 @@ class MutableAclProviderTest extends TestCase
         ;
         $con
             ->expects($this->never())
-            ->method('executeUpdate')
+            ->method('executeStatement')
         ;
 
         $provider = new MutableAclProvider($con, new PermissionGrantingStrategy(), []);
@@ -536,7 +536,6 @@ class MutableAclProviderTest extends TestCase
             ],
             $configuration
         );
-        $this->connection->setNestTransactionsWithSavepoints(true);
 
         // import the schema
         $schema = new Schema($this->getOptions());
@@ -547,6 +546,7 @@ class MutableAclProviderTest extends TestCase
 
     protected function tearDown(): void
     {
+        $this->connection->close();
         $this->connection = null;
     }
 

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "doctrine/cache": "^1.11|^2.0",
         "doctrine/common": "^2.2|^3",
         "doctrine/persistence": "^1.3.3|^2|^3",
-        "doctrine/dbal": "^2.13.1|^3.1",
+        "doctrine/dbal": "^2.13.1|^3.1|^4",
         "psr/log": "^1|^2|^3"
     },
     "autoload": {


### PR DESCRIPTION
Call to Table::addForeignKeyConstraint now expects only a string for the table argument, so ensure we send table name instead of Table object.