### PR TITLE
Fix PHP 8.4 implicitly nullable deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,12 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: ['7.2.5', '7.3', '7.4', '8.0', '8.1', '8.2']
+                php: ['7.2.5', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
                 include:
                     - php: '7.4'
                       deps: lowest
                       deprecations: max[self]=0
-                    - php: '8.0'
+                    - php: '8.4'
                       deps: highest
 
         steps:

--- a/Dbal/AclProvider.php
+++ b/Dbal/AclProvider.php
@@ -56,7 +56,7 @@ class AclProvider implements AclProviderInterface
      */
     private $permissionGrantingStrategy;
 
-    public function __construct(Connection $connection, PermissionGrantingStrategyInterface $permissionGrantingStrategy, array $options, AclCacheInterface $cache = null)
+    public function __construct(Connection $connection, PermissionGrantingStrategyInterface $permissionGrantingStrategy, array $options, ?AclCacheInterface $cache = null)
     {
         $this->cache = $cache;
         $this->connection = $connection;

--- a/Dbal/MutableAclProvider.php
+++ b/Dbal/MutableAclProvider.php
@@ -40,7 +40,7 @@ class MutableAclProvider extends AclProvider implements MutableAclProviderInterf
     /**
      * {@inheritdoc}
      */
-    public function __construct(Connection $connection, PermissionGrantingStrategyInterface $permissionGrantingStrategy, array $options, AclCacheInterface $cache = null)
+    public function __construct(Connection $connection, PermissionGrantingStrategyInterface $permissionGrantingStrategy, array $options, ?AclCacheInterface $cache = null)
     {
         parent::__construct($connection, $permissionGrantingStrategy, $options, $cache);
 

--- a/Dbal/Schema.php
+++ b/Dbal/Schema.php
@@ -29,7 +29,7 @@ final class Schema extends BaseSchema
     /**
      * @param array $options the names for tables
      */
-    public function __construct(array $options, Connection $connection = null)
+    public function __construct(array $options, ?Connection $connection = null)
     {
         $schemaConfig = $this->createSchemaConfig($connection);
 

--- a/Voter/AclVoter.php
+++ b/Voter/AclVoter.php
@@ -62,7 +62,7 @@ class AclVoter implements VoterInterface
     private $allowIfObjectIdentityUnavailable;
     private $logger;
 
-    public function __construct(AclProviderInterface $aclProvider, ObjectIdentityRetrievalStrategyInterface $oidRetrievalStrategy, SecurityIdentityRetrievalStrategyInterface $sidRetrievalStrategy, PermissionMapInterface $permissionMap, LoggerInterface $logger = null, $allowIfObjectIdentityUnavailable = true)
+    public function __construct(AclProviderInterface $aclProvider, ObjectIdentityRetrievalStrategyInterface $oidRetrievalStrategy, SecurityIdentityRetrievalStrategyInterface $sidRetrievalStrategy, PermissionMapInterface $permissionMap, ?LoggerInterface $logger = null, $allowIfObjectIdentityUnavailable = true)
     {
         $this->aclProvider = $aclProvider;
         $this->permissionMap = $permissionMap;


### PR DESCRIPTION
Fix the ` Implicitly marking parameter XXX as nullable is deprecated, the explicit nullable type must be used instead` deprecation in PHP 8.4

This PR also enables to CI build against php 8.3 and 8.4