### PR TITLE
Raise minimum dependencies to php, symfony/* and doctrine/dbal packages

### DIFF
--- a/Dbal/Schema.php
+++ b/Dbal/Schema.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -12,6 +14,7 @@
 namespace Symfony\Component\Security\Acl\Dbal;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Schema\Schema as BaseSchema;
 use Doctrine\DBAL\Schema\SchemaConfig;
@@ -23,20 +26,18 @@ use Doctrine\DBAL\Schema\SchemaConfig;
  */
 final class Schema extends BaseSchema
 {
-    protected $options;
-    protected $platform;
+    protected ?AbstractPlatform $platform;
 
     /**
-     * @param array $options the names for tables
+     * @param array<string,string> $options the names for tables
      */
-    public function __construct(array $options, Connection $connection = null)
+    public function __construct(protected array $options, ?Connection $connection = null)
     {
         $schemaConfig = $this->createSchemaConfig($connection);
 
         parent::__construct([], [], $schemaConfig);
 
-        $this->options = $options;
-        $this->platform = $connection ? $connection->getDatabasePlatform() : null;
+        $this->platform = $connection?->getDatabasePlatform();
 
         $this->addClassTable();
         $this->addSecurityIdentitiesTable();
@@ -48,7 +49,7 @@ final class Schema extends BaseSchema
     /**
      * Merges ACL schema with the given schema.
      */
-    public function addToSchema(BaseSchema $schema)
+    public function addToSchema(BaseSchema $schema): void
     {
         foreach ($this->getTables() as $table) {
             $schema->_addTable($table);
@@ -62,7 +63,7 @@ final class Schema extends BaseSchema
     /**
      * Adds the class table to the schema.
      */
-    protected function addClassTable()
+    protected function addClassTable(): void
     {
         $table = $this->createTable($this->options['class_table_name']);
         $table->addColumn('id', 'integer', ['unsigned' => true, 'autoincrement' => true]);
@@ -74,7 +75,7 @@ final class Schema extends BaseSchema
     /**
      * Adds the entry table to the schema.
      */
-    protected function addEntryTable()
+    protected function addEntryTable(): void
     {
         $table = $this->createTable($this->options['entry_table_name']);
 
@@ -102,7 +103,7 @@ final class Schema extends BaseSchema
     /**
      * Adds the object identity table to the schema.
      */
-    protected function addObjectIdentitiesTable()
+    protected function addObjectIdentitiesTable(): void
     {
         $table = $this->createTable($this->options['oid_table_name']);
 
@@ -122,7 +123,7 @@ final class Schema extends BaseSchema
     /**
      * Adds the object identity relation table to the schema.
      */
-    protected function addObjectIdentityAncestorsTable()
+    protected function addObjectIdentityAncestorsTable(): void
     {
         $table = $this->createTable($this->options['oid_ancestors_table_name']);
 
@@ -144,7 +145,7 @@ final class Schema extends BaseSchema
     /**
      * Adds the security identity table to the schema.
      */
-    protected function addSecurityIdentitiesTable()
+    protected function addSecurityIdentitiesTable(): void
     {
         $table = $this->createTable($this->options['sid_table_name']);
 
@@ -162,11 +163,6 @@ final class Schema extends BaseSchema
             return null;
         }
 
-        $schemaManager = method_exists($connection, 'createSchemaManager')
-            ? $connection->createSchemaManager()
-            : $connection->getSchemaManager()
-        ;
-
-        return $schemaManager->createSchemaConfig();
+        return $connection->createSchemaManager()->createSchemaConfig();
     }
 }

--- a/Domain/Acl.php
+++ b/Domain/Acl.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -35,39 +37,49 @@ use Symfony\Component\Security\Acl\Model\SecurityIdentityInterface;
  */
 class Acl implements AuditableAclInterface, NotifyPropertyChanged
 {
-    private $parentAcl;
-    private $permissionGrantingStrategy;
-    private $objectIdentity;
-    private $classAces = [];
-    private $classFieldAces = [];
-    private $objectAces = [];
-    private $objectFieldAces = [];
-    private $id;
-    private $loadedSids;
-    private $entriesInheriting;
-    private $listeners = [];
+    private AclInterface|int|null $parentAcl = null;
 
     /**
-     * Constructor.
-     *
-     * @param int  $id
-     * @param bool $entriesInheriting
+     * @var Entry[]
      */
-    public function __construct($id, ObjectIdentityInterface $objectIdentity, PermissionGrantingStrategyInterface $permissionGrantingStrategy, array $loadedSids, $entriesInheriting)
-    {
-        $this->id = $id;
-        $this->objectIdentity = $objectIdentity;
-        $this->permissionGrantingStrategy = $permissionGrantingStrategy;
-        $this->loadedSids = $loadedSids;
-        $this->entriesInheriting = $entriesInheriting;
+    private array $classAces = [];
+
+    /**
+     * @var array<string,Entry[]>
+     */
+    private array $classFieldAces = [];
+
+    /**
+     * @var Entry[]
+     */
+    private array $objectAces = [];
+
+    /**
+     * @var array<string,Entry[]>
+     */
+    private array $objectFieldAces = [];
+
+    /**
+     * @var PropertyChangedListener[]
+     */
+    private array $listeners = [];
+
+    /**
+     * @param SecurityIdentityInterface[] $loadedSids
+     */
+    public function __construct(
+        private int $id,
+        private ObjectIdentityInterface $objectIdentity,
+        private PermissionGrantingStrategyInterface $permissionGrantingStrategy,
+        private array $loadedSids,
+        private bool $entriesInheriting,
+    ) {
     }
 
     /**
      * Adds a property changed listener.
-     *
-     * @return void
      */
-    public function addPropertyChangedListener(PropertyChangedListener $listener)
+    public function addPropertyChangedListener(PropertyChangedListener $listener): void
     {
         $this->listeners[] = $listener;
     }
@@ -75,7 +87,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * {@inheritdoc}
      */
-    public function deleteClassAce(int $index)
+    public function deleteClassAce(int $index): void
     {
         $this->deleteAce('classAces', $index);
     }
@@ -83,7 +95,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * {@inheritdoc}
      */
-    public function deleteClassFieldAce(int $index, string $field)
+    public function deleteClassFieldAce(int $index, string $field): void
     {
         $this->deleteFieldAce('classFieldAces', $index, $field);
     }
@@ -91,7 +103,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * {@inheritdoc}
      */
-    public function deleteObjectAce(int $index)
+    public function deleteObjectAce(int $index): void
     {
         $this->deleteAce('objectAces', $index);
     }
@@ -99,7 +111,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * {@inheritdoc}
      */
-    public function deleteObjectFieldAce(int $index, string $field)
+    public function deleteObjectFieldAce(int $index, string $field): void
     {
         $this->deleteFieldAce('objectFieldAces', $index, $field);
     }
@@ -107,7 +119,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * {@inheritdoc}
      */
-    public function getClassAces()
+    public function getClassAces(): array
     {
         return $this->classAces;
     }
@@ -115,7 +127,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * {@inheritdoc}
      */
-    public function getClassFieldAces(string $field)
+    public function getClassFieldAces(string $field): array
     {
         return $this->classFieldAces[$field] ?? [];
     }
@@ -123,7 +135,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * {@inheritdoc}
      */
-    public function getObjectAces()
+    public function getObjectAces(): array
     {
         return $this->objectAces;
     }
@@ -131,7 +143,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * {@inheritdoc}
      */
-    public function getObjectFieldAces(string $field)
+    public function getObjectFieldAces(string $field): array
     {
         return $this->objectFieldAces[$field] ?? [];
     }
@@ -139,7 +151,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * {@inheritdoc}
      */
-    public function getId()
+    public function getId(): int
     {
         return $this->id;
     }
@@ -147,7 +159,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * {@inheritdoc}
      */
-    public function getObjectIdentity()
+    public function getObjectIdentity(): ObjectIdentityInterface
     {
         return $this->objectIdentity;
     }
@@ -155,7 +167,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * {@inheritdoc}
      */
-    public function getParentAcl()
+    public function getParentAcl(): AclInterface|int|null
     {
         return $this->parentAcl;
     }
@@ -163,7 +175,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * {@inheritdoc}
      */
-    public function insertClassAce(SecurityIdentityInterface $sid, int $mask, int $index = 0, bool $granting = true, ?string $strategy = null)
+    public function insertClassAce(SecurityIdentityInterface $sid, int $mask, int $index = 0, bool $granting = true, ?string $strategy = null): void
     {
         $this->insertAce('classAces', $index, $mask, $sid, $granting, $strategy);
     }
@@ -171,7 +183,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * {@inheritdoc}
      */
-    public function insertClassFieldAce(string $field, SecurityIdentityInterface $sid, int $mask, int $index = 0, bool $granting = true, ?string $strategy = null)
+    public function insertClassFieldAce(string $field, SecurityIdentityInterface $sid, int $mask, int $index = 0, bool $granting = true, ?string $strategy = null): void
     {
         $this->insertFieldAce('classFieldAces', $index, $field, $mask, $sid, $granting, $strategy);
     }
@@ -179,7 +191,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * {@inheritdoc}
      */
-    public function insertObjectAce(SecurityIdentityInterface $sid, int $mask, int $index = 0, bool $granting = true, ?string $strategy = null)
+    public function insertObjectAce(SecurityIdentityInterface $sid, int $mask, int $index = 0, bool $granting = true, ?string $strategy = null): void
     {
         $this->insertAce('objectAces', $index, $mask, $sid, $granting, $strategy);
     }
@@ -187,7 +199,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * {@inheritdoc}
      */
-    public function insertObjectFieldAce(string $field, SecurityIdentityInterface $sid, int $mask, int $index = 0, bool $granting = true, ?string $strategy = null)
+    public function insertObjectFieldAce(string $field, SecurityIdentityInterface $sid, int $mask, int $index = 0, bool $granting = true, ?string $strategy = null): void
     {
         $this->insertFieldAce('objectFieldAces', $index, $field, $mask, $sid, $granting, $strategy);
     }
@@ -195,7 +207,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * {@inheritdoc}
      */
-    public function isEntriesInheriting()
+    public function isEntriesInheriting(): bool
     {
         return $this->entriesInheriting;
     }
@@ -203,7 +215,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * {@inheritdoc}
      */
-    public function isFieldGranted(string $field, array $masks, array $securityIdentities, bool $administrativeMode = false)
+    public function isFieldGranted(string $field, array $masks, array $securityIdentities, bool $administrativeMode = false): bool
     {
         return $this->permissionGrantingStrategy->isFieldGranted($this, $field, $masks, $securityIdentities, $administrativeMode);
     }
@@ -211,7 +223,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * {@inheritdoc}
      */
-    public function isGranted(array $masks, array $securityIdentities, bool $administrativeMode = false)
+    public function isGranted(array $masks, array $securityIdentities, bool $administrativeMode = false): bool
     {
         return $this->permissionGrantingStrategy->isGranted($this, $masks, $securityIdentities, $administrativeMode);
     }
@@ -219,21 +231,13 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * {@inheritdoc}
      */
-    public function isSidLoaded($securityIdentities)
+    public function isSidLoaded(SecurityIdentityInterface ...$securityIdentities): bool
     {
         if (!$this->loadedSids) {
             return true;
         }
 
-        if (!\is_array($securityIdentities)) {
-            $securityIdentities = [$securityIdentities];
-        }
-
         foreach ($securityIdentities as $sid) {
-            if (!$sid instanceof SecurityIdentityInterface) {
-                throw new \InvalidArgumentException('$sid must be an instance of SecurityIdentityInterface.');
-            }
-
             foreach ($this->loadedSids as $loadedSid) {
                 if ($loadedSid->equals($sid)) {
                     continue 2;
@@ -249,7 +253,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     public function __serialize(): array
     {
         return [
-            null === $this->parentAcl ? null : $this->parentAcl->getId(),
+            $this->parentAcl?->getId(),
             $this->objectIdentity,
             $this->classAces,
             $this->classFieldAces,
@@ -271,7 +275,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
             $this->objectFieldAces,
             $this->id,
             $this->loadedSids,
-            $this->entriesInheriting
+            $this->entriesInheriting,
         ] = $data;
 
         $this->listeners = [];
@@ -294,17 +298,17 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
      *
      * @final
      *
-     * @param string $serialized
+     * @param string $data
      */
-    public function unserialize($serialized)
+    public function unserialize($data)
     {
-        $this->__unserialize(\is_array($serialized) ? $serialized : unserialize($serialized));
+        $this->__unserialize(unserialize($data));
     }
 
     /**
      * {@inheritdoc}
      */
-    public function setEntriesInheriting(bool $boolean)
+    public function setEntriesInheriting(bool $boolean): void
     {
         if ($this->entriesInheriting !== $boolean) {
             $this->onPropertyChanged('entriesInheriting', $this->entriesInheriting, $boolean);
@@ -315,7 +319,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * {@inheritdoc}
      */
-    public function setParentAcl(?AclInterface $acl = null)
+    public function setParentAcl(?AclInterface $acl = null): void
     {
         if (null !== $acl && null === $acl->getId()) {
             throw new \InvalidArgumentException('$acl must have an ID.');
@@ -330,7 +334,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * {@inheritdoc}
      */
-    public function updateClassAce(int $index, int $mask, ?string $strategy = null)
+    public function updateClassAce(int $index, int $mask, ?string $strategy = null): void
     {
         $this->updateAce('classAces', $index, $mask, $strategy);
     }
@@ -338,7 +342,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * {@inheritdoc}
      */
-    public function updateClassFieldAce(int $index, string $field, int $mask, ?string $strategy = null)
+    public function updateClassFieldAce(int $index, string $field, int $mask, ?string $strategy = null): void
     {
         $this->updateFieldAce('classFieldAces', $index, $field, $mask, $strategy);
     }
@@ -346,7 +350,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * {@inheritdoc}
      */
-    public function updateObjectAce(int $index, int $mask, ?string $strategy = null)
+    public function updateObjectAce(int $index, int $mask, ?string $strategy = null): void
     {
         $this->updateAce('objectAces', $index, $mask, $strategy);
     }
@@ -354,7 +358,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * {@inheritdoc}
      */
-    public function updateObjectFieldAce(int $index, string $field, int $mask, ?string $strategy = null)
+    public function updateObjectFieldAce(int $index, string $field, int $mask, ?string $strategy = null): void
     {
         $this->updateFieldAce('objectFieldAces', $index, $field, $mask, $strategy);
     }
@@ -362,7 +366,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * {@inheritdoc}
      */
-    public function updateClassAuditing(int $index, bool $auditSuccess, bool $auditFailure)
+    public function updateClassAuditing(int $index, bool $auditSuccess, bool $auditFailure): void
     {
         $this->updateAuditing($this->classAces, $index, $auditSuccess, $auditFailure);
     }
@@ -370,7 +374,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * {@inheritdoc}
      */
-    public function updateClassFieldAuditing(int $index, string $field, bool $auditSuccess, bool $auditFailure)
+    public function updateClassFieldAuditing(int $index, string $field, bool $auditSuccess, bool $auditFailure): void
     {
         if (!isset($this->classFieldAces[$field])) {
             throw new \InvalidArgumentException(sprintf('There are no ACEs for field "%s".', $field));
@@ -382,7 +386,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * {@inheritdoc}
      */
-    public function updateObjectAuditing(int $index, bool $auditSuccess, bool $auditFailure)
+    public function updateObjectAuditing(int $index, bool $auditSuccess, bool $auditFailure): void
     {
         $this->updateAuditing($this->objectAces, $index, $auditSuccess, $auditFailure);
     }
@@ -390,7 +394,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * {@inheritdoc}
      */
-    public function updateObjectFieldAuditing(int $index, string $field, bool $auditSuccess, bool $auditFailure)
+    public function updateObjectFieldAuditing(int $index, string $field, bool $auditSuccess, bool $auditFailure): void
     {
         if (!isset($this->objectFieldAces[$field])) {
             throw new \InvalidArgumentException(sprintf('There are no ACEs for field "%s".', $field));
@@ -402,12 +406,9 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * Deletes an ACE.
      *
-     * @param string $property
-     * @param int    $index
-     *
      * @throws \OutOfBoundsException
      */
-    private function deleteAce($property, $index)
+    private function deleteAce(string $property, int $index): void
     {
         $aces = &$this->$property;
         if (!isset($aces[$index])) {
@@ -427,13 +428,9 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * Deletes a field-based ACE.
      *
-     * @param string $property
-     * @param int    $index
-     * @param string $field
-     *
      * @throws \OutOfBoundsException
      */
-    private function deleteFieldAce($property, $index, $field)
+    private function deleteFieldAce(string $property, int $index, string $field): void
     {
         $aces = &$this->$property;
         if (!isset($aces[$field][$index])) {
@@ -453,23 +450,13 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * Inserts an ACE.
      *
-     * @param string $property
-     * @param int    $index
-     * @param int    $mask
-     * @param bool   $granting
-     * @param string $strategy
-     *
      * @throws \OutOfBoundsException
      * @throws \InvalidArgumentException
      */
-    private function insertAce($property, $index, $mask, SecurityIdentityInterface $sid, $granting, $strategy = null)
+    private function insertAce(string $property, int $index, int $mask, SecurityIdentityInterface $sid, bool $granting, ?string $strategy = null): void
     {
         if ($index < 0 || $index > \count($this->$property)) {
             throw new \OutOfBoundsException(sprintf('The index must be in the interval [0, %d].', \count($this->$property)));
-        }
-
-        if (!\is_int($mask)) {
-            throw new \InvalidArgumentException('$mask must be an integer.');
         }
 
         if (null === $strategy) {
@@ -501,25 +488,13 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * Inserts a field-based ACE.
      *
-     * @param string $property
-     * @param int    $index
-     * @param string $field
-     * @param int    $mask
-     * @param bool   $granting
-     * @param string $strategy
-     *
      * @throws \InvalidArgumentException
      * @throws \OutOfBoundsException
      */
-    private function insertFieldAce($property, $index, $field, $mask, SecurityIdentityInterface $sid, $granting, $strategy = null)
+    private function insertFieldAce(string $property, int $index, string $field, int $mask, SecurityIdentityInterface $sid, bool $granting, ?string $strategy = null): void
     {
-        $field = (string) $field;
         if ('' === $field) {
             throw new \InvalidArgumentException('$field cannot be empty.');
-        }
-
-        if (!\is_int($mask)) {
-            throw new \InvalidArgumentException('$mask must be an integer.');
         }
 
         if (null === $strategy) {
@@ -559,14 +534,9 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * Updates an ACE.
      *
-     * @param string $property
-     * @param int    $index
-     * @param int    $mask
-     * @param string $strategy
-     *
      * @throws \OutOfBoundsException
      */
-    private function updateAce($property, $index, $mask, $strategy = null)
+    private function updateAce(string $property, int $index, int $mask, ?string $strategy = null): void
     {
         $aces = &$this->$property;
         if (!isset($aces[$index])) {
@@ -587,13 +557,11 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * Updates auditing for an ACE.
      *
-     * @param int  $index
-     * @param bool $auditSuccess
-     * @param bool $auditFailure
+     * @param array<int,Entry> &$aces
      *
      * @throws \OutOfBoundsException
      */
-    private function updateAuditing(array &$aces, $index, $auditSuccess, $auditFailure)
+    private function updateAuditing(array &$aces, int $index, bool $auditSuccess, bool $auditFailure): void
     {
         if (!isset($aces[$index])) {
             throw new \OutOfBoundsException(sprintf('The index "%d" does not exist.', $index));
@@ -613,18 +581,11 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * Updates a field-based ACE.
      *
-     * @param string $property
-     * @param int    $index
-     * @param string $field
-     * @param int    $mask
-     * @param string $strategy
-     *
      * @throws \InvalidArgumentException
      * @throws \OutOfBoundsException
      */
-    private function updateFieldAce($property, $index, $field, $mask, $strategy = null)
+    private function updateFieldAce(string $property, int $index, string $field, int $mask, ?string $strategy = null): void
     {
-        $field = (string) $field;
         if ('' === $field) {
             throw new \InvalidArgumentException('$field cannot be empty.');
         }
@@ -647,12 +608,8 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
 
     /**
      * Called when a property of the ACL changes.
-     *
-     * @param string $name
-     * @param mixed  $oldValue
-     * @param mixed  $newValue
      */
-    private function onPropertyChanged($name, $oldValue, $newValue)
+    private function onPropertyChanged(string $name, mixed $oldValue, mixed $newValue): void
     {
         foreach ($this->listeners as $listener) {
             $listener->propertyChanged($this, $name, $oldValue, $newValue);
@@ -661,12 +618,8 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
 
     /**
      * Called when a property of an ACE associated with this ACL changes.
-     *
-     * @param string $name
-     * @param mixed  $oldValue
-     * @param mixed  $newValue
      */
-    private function onEntryPropertyChanged(EntryInterface $entry, $name, $oldValue, $newValue)
+    private function onEntryPropertyChanged(EntryInterface $entry, string $name, mixed $oldValue, mixed $newValue): void
     {
         foreach ($this->listeners as $listener) {
             $listener->propertyChanged($entry, $name, $oldValue, $newValue);

--- a/Domain/AclCacheTrait.php
+++ b/Domain/AclCacheTrait.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -13,6 +15,7 @@ namespace Symfony\Component\Security\Acl\Domain;
 
 use Symfony\Component\Security\Acl\Model\AclInterface;
 use Symfony\Component\Security\Acl\Model\ObjectIdentityInterface;
+use Symfony\Component\Security\Acl\Model\PermissionGrantingStrategyInterface;
 
 /**
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
@@ -21,8 +24,8 @@ use Symfony\Component\Security\Acl\Model\ObjectIdentityInterface;
  */
 trait AclCacheTrait
 {
-    private $prefix;
-    private $permissionGrantingStrategy;
+    private string $prefix;
+    private PermissionGrantingStrategyInterface $permissionGrantingStrategy;
 
     /**
      * Unserializes the ACL.

--- a/Domain/AclCollectionCache.php
+++ b/Domain/AclCollectionCache.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -23,28 +25,21 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
  */
 class AclCollectionCache
 {
-    private $aclProvider;
-    private $objectIdentityRetrievalStrategy;
-    private $securityIdentityRetrievalStrategy;
-
-    /**
-     * Constructor.
-     */
-    public function __construct(AclProviderInterface $aclProvider, ObjectIdentityRetrievalStrategyInterface $oidRetrievalStrategy, SecurityIdentityRetrievalStrategyInterface $sidRetrievalStrategy)
-    {
-        $this->aclProvider = $aclProvider;
-        $this->objectIdentityRetrievalStrategy = $oidRetrievalStrategy;
-        $this->securityIdentityRetrievalStrategy = $sidRetrievalStrategy;
+    public function __construct(
+        private AclProviderInterface $aclProvider,
+        private ObjectIdentityRetrievalStrategyInterface $objectIdentityRetrievalStrategy,
+        private SecurityIdentityRetrievalStrategyInterface $securityIdentityRetrievalStrategy,
+    ) {
     }
 
     /**
      * Batch loads ACLs for an entire collection; thus, it reduces the number
      * of required queries considerably.
      *
-     * @param mixed            $collection anything that can be passed to foreach()
+     * @param object[]         $collection anything that can be passed to foreach()
      * @param TokenInterface[] $tokens     an array of TokenInterface implementations
      */
-    public function cache($collection, array $tokens = [])
+    public function cache(iterable $collection, array $tokens = []): void
     {
         $sids = [];
         foreach ($tokens as $token) {

--- a/Domain/AuditLogger.php
+++ b/Domain/AuditLogger.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -24,10 +26,8 @@ abstract class AuditLogger implements AuditLoggerInterface
 {
     /**
      * Performs some checks if logging was requested.
-     *
-     * @param bool $granted
      */
-    public function logIfNeeded($granted, EntryInterface $ace)
+    public function logIfNeeded(bool $granted, EntryInterface $ace): void
     {
         if (!$ace instanceof AuditableEntryInterface) {
             return;
@@ -42,8 +42,6 @@ abstract class AuditLogger implements AuditLoggerInterface
 
     /**
      * This method is only called when logging is needed.
-     *
-     * @param bool $granted
      */
-    abstract protected function doLog($granted, EntryInterface $ace);
+    abstract protected function doLog(bool $granted, EntryInterface $ace): void;
 }

--- a/Domain/Entry.php
+++ b/Domain/Entry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -22,39 +24,30 @@ use Symfony\Component\Security\Acl\Model\SecurityIdentityInterface;
  */
 class Entry implements AuditableEntryInterface
 {
-    private $acl;
-    private $mask;
-    private $id;
-    private $securityIdentity;
-    private $strategy;
-    private $auditFailure;
-    private $auditSuccess;
-    private $granting;
-
-    public function __construct(?int $id, AclInterface $acl, SecurityIdentityInterface $sid, string $strategy, int $mask, bool $granting, bool $auditFailure, bool $auditSuccess)
-    {
-        $this->id = $id;
-        $this->acl = $acl;
-        $this->securityIdentity = $sid;
-        $this->strategy = $strategy;
-        $this->mask = $mask;
-        $this->granting = $granting;
-        $this->auditFailure = $auditFailure;
-        $this->auditSuccess = $auditSuccess;
+    public function __construct(
+        private ?int $id,
+        private readonly AclInterface $acl,
+        private readonly SecurityIdentityInterface $securityIdentity,
+        private string $strategy,
+        private int $mask,
+        private bool $granting,
+        private bool $auditFailure,
+        private bool $auditSuccess,
+    ) {
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getAcl()
+    public function getAcl(): ?AclInterface
     {
-        return $this->acl;
+        return $this->acl ?? null;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getMask()
+    public function getMask(): int
     {
         return $this->mask;
     }
@@ -62,7 +55,7 @@ class Entry implements AuditableEntryInterface
     /**
      * {@inheritdoc}
      */
-    public function getId()
+    public function getId(): ?int
     {
         return $this->id;
     }
@@ -70,7 +63,7 @@ class Entry implements AuditableEntryInterface
     /**
      * {@inheritdoc}
      */
-    public function getSecurityIdentity()
+    public function getSecurityIdentity(): SecurityIdentityInterface
     {
         return $this->securityIdentity;
     }
@@ -78,7 +71,7 @@ class Entry implements AuditableEntryInterface
     /**
      * {@inheritdoc}
      */
-    public function getStrategy()
+    public function getStrategy(): string
     {
         return $this->strategy;
     }
@@ -86,7 +79,7 @@ class Entry implements AuditableEntryInterface
     /**
      * {@inheritdoc}
      */
-    public function isAuditFailure()
+    public function isAuditFailure(): bool
     {
         return $this->auditFailure;
     }
@@ -94,7 +87,7 @@ class Entry implements AuditableEntryInterface
     /**
      * {@inheritdoc}
      */
-    public function isAuditSuccess()
+    public function isAuditSuccess(): bool
     {
         return $this->auditSuccess;
     }
@@ -102,7 +95,7 @@ class Entry implements AuditableEntryInterface
     /**
      * {@inheritdoc}
      */
-    public function isGranting()
+    public function isGranting(): bool
     {
         return $this->granting;
     }
@@ -112,10 +105,8 @@ class Entry implements AuditableEntryInterface
      *
      * Do never call this method directly. Use the respective methods on the
      * AclInterface instead.
-     *
-     * @param bool $boolean
      */
-    public function setAuditFailure($boolean)
+    public function setAuditFailure(bool $boolean): void
     {
         $this->auditFailure = $boolean;
     }
@@ -125,10 +116,8 @@ class Entry implements AuditableEntryInterface
      *
      * Do never call this method directly. Use the respective methods on the
      * AclInterface instead.
-     *
-     * @param bool $boolean
      */
-    public function setAuditSuccess($boolean)
+    public function setAuditSuccess(bool $boolean): void
     {
         $this->auditSuccess = $boolean;
     }
@@ -138,10 +127,8 @@ class Entry implements AuditableEntryInterface
      *
      * Do never call this method directly. Use the respective methods on the
      * AclInterface instead.
-     *
-     * @param int $mask
      */
-    public function setMask($mask)
+    public function setMask(int $mask): void
     {
         $this->mask = $mask;
     }
@@ -151,10 +138,8 @@ class Entry implements AuditableEntryInterface
      *
      * Do never call this method directly. Use the respective methods on the
      * AclInterface instead.
-     *
-     * @param string $strategy
      */
-    public function setStrategy($strategy)
+    public function setStrategy(string $strategy): void
     {
         $this->strategy = $strategy;
     }
@@ -180,7 +165,7 @@ class Entry implements AuditableEntryInterface
             $this->strategy,
             $this->auditFailure,
             $this->auditSuccess,
-            $this->granting
+            $this->granting,
         ] = $data;
     }
 
@@ -201,10 +186,10 @@ class Entry implements AuditableEntryInterface
      *
      * @final
      *
-     * @param string $serialized
+     * @param string $data
      */
-    public function unserialize($serialized)
+    public function unserialize($data)
     {
-        $this->__unserialize(\is_array($serialized) ? $serialized : unserialize($serialized));
+        $this->__unserialize(unserialize($data));
     }
 }

--- a/Domain/FieldEntry.php
+++ b/Domain/FieldEntry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -22,19 +24,24 @@ use Symfony\Component\Security\Acl\Model\SecurityIdentityInterface;
  */
 class FieldEntry extends Entry implements FieldEntryInterface
 {
-    private $field;
-
-    public function __construct(?int $id, AclInterface $acl, string $field, SecurityIdentityInterface $sid, string $strategy, int $mask, bool $granting, bool $auditFailure, $auditSuccess)
-    {
+    public function __construct(
+        ?int $id,
+        AclInterface $acl,
+        private readonly string $field,
+        SecurityIdentityInterface $sid,
+        string $strategy,
+        int $mask,
+        bool $granting,
+        bool $auditFailure,
+        bool $auditSuccess,
+    ) {
         parent::__construct($id, $acl, $sid, $strategy, $mask, $granting, $auditFailure, $auditSuccess);
-
-        $this->field = $field;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getField()
+    public function getField(): string
     {
         return $this->field;
     }

--- a/Domain/ObjectIdentity.php
+++ b/Domain/ObjectIdentity.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -23,45 +25,32 @@ use Symfony\Component\Security\Acl\Util\ClassUtils;
  */
 final class ObjectIdentity implements ObjectIdentityInterface
 {
-    private $identifier;
-    private $type;
+    private readonly string $identifier;
 
     /**
-     * Constructor.
-     *
-     * @param string $identifier
-     * @param string $type
-     *
      * @throws \InvalidArgumentException
      */
-    public function __construct($identifier, $type)
-    {
-        if ('' === $identifier) {
+    public function __construct(
+        string|int $identifier,
+        private readonly string $type,
+    ) {
+        $this->identifier = (string) $identifier;
+
+        if ('' === $this->identifier) {
             throw new \InvalidArgumentException('$identifier cannot be empty.');
         }
         if (empty($type)) {
             throw new \InvalidArgumentException('$type cannot be empty.');
         }
-
-        $this->identifier = $identifier;
-        $this->type = $type;
     }
 
     /**
      * Constructs an ObjectIdentity for the given domain object.
      *
-     * @param object $domainObject
-     *
-     * @return ObjectIdentity
-     *
      * @throws InvalidDomainObjectException
      */
-    public static function fromDomainObject($domainObject)
+    public static function fromDomainObject(object $domainObject): self
     {
-        if (!\is_object($domainObject)) {
-            throw new InvalidDomainObjectException('$domainObject must be an object.');
-        }
-
         try {
             if ($domainObject instanceof DomainObjectInterface) {
                 return new self($domainObject->getObjectIdentifier(), ClassUtils::getRealClass($domainObject));
@@ -78,7 +67,7 @@ final class ObjectIdentity implements ObjectIdentityInterface
     /**
      * {@inheritdoc}
      */
-    public function getIdentifier()
+    public function getIdentifier(): string
     {
         return $this->identifier;
     }
@@ -86,7 +75,7 @@ final class ObjectIdentity implements ObjectIdentityInterface
     /**
      * {@inheritdoc}
      */
-    public function getType()
+    public function getType(): string
     {
         return $this->type;
     }
@@ -94,7 +83,7 @@ final class ObjectIdentity implements ObjectIdentityInterface
     /**
      * {@inheritdoc}
      */
-    public function equals(ObjectIdentityInterface $identity)
+    public function equals(ObjectIdentityInterface $identity): bool
     {
         // comparing the identifier with === might lead to problems, so we
         // waive this restriction

--- a/Domain/ObjectIdentityRetrievalStrategy.php
+++ b/Domain/ObjectIdentityRetrievalStrategy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -12,6 +14,7 @@
 namespace Symfony\Component\Security\Acl\Domain;
 
 use Symfony\Component\Security\Acl\Exception\InvalidDomainObjectException;
+use Symfony\Component\Security\Acl\Model\ObjectIdentityInterface;
 use Symfony\Component\Security\Acl\Model\ObjectIdentityRetrievalStrategyInterface;
 
 /**
@@ -24,12 +27,12 @@ class ObjectIdentityRetrievalStrategy implements ObjectIdentityRetrievalStrategy
     /**
      * {@inheritdoc}
      */
-    public function getObjectIdentity($domainObject)
+    public function getObjectIdentity(object $domainObject): ?ObjectIdentityInterface
     {
         try {
             return ObjectIdentity::fromDomainObject($domainObject);
         } catch (InvalidDomainObjectException $e) {
-            return;
+            return null;
         }
     }
 }

--- a/Domain/PermissionGrantingStrategy.php
+++ b/Domain/PermissionGrantingStrategy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -29,12 +31,12 @@ class PermissionGrantingStrategy implements PermissionGrantingStrategyInterface
     public const ALL = 'all';
     public const ANY = 'any';
 
-    private $auditLogger;
+    private ?AuditLoggerInterface $auditLogger = null;
 
     /**
      * Sets the audit logger.
      */
-    public function setAuditLogger(AuditLoggerInterface $auditLogger)
+    public function setAuditLogger(AuditLoggerInterface $auditLogger): void
     {
         $this->auditLogger = $auditLogger;
     }
@@ -42,7 +44,7 @@ class PermissionGrantingStrategy implements PermissionGrantingStrategyInterface
     /**
      * {@inheritdoc}
      */
-    public function isGranted(AclInterface $acl, array $masks, array $sids, $administrativeMode = false)
+    public function isGranted(AclInterface $acl, array $masks, array $sids, bool $administrativeMode = false): bool
     {
         try {
             try {
@@ -74,7 +76,7 @@ class PermissionGrantingStrategy implements PermissionGrantingStrategyInterface
     /**
      * {@inheritdoc}
      */
-    public function isFieldGranted(AclInterface $acl, $field, array $masks, array $sids, $administrativeMode = false)
+    public function isFieldGranted(AclInterface $acl, string $field, array $masks, array $sids, bool $administrativeMode = false): bool
     {
         try {
             try {
@@ -123,7 +125,7 @@ class PermissionGrantingStrategy implements PermissionGrantingStrategyInterface
      * an NoAceFoundException, or deny access.
      *
      * @param EntryInterface[]            $aces               An array of ACE to check against
-     * @param array                       $masks              An array of permission masks
+     * @param int[]                       $masks              An array of permission masks
      * @param SecurityIdentityInterface[] $sids               An array of SecurityIdentityInterface implementations
      * @param bool                        $administrativeMode True turns off audit logging
      *
@@ -131,7 +133,7 @@ class PermissionGrantingStrategy implements PermissionGrantingStrategyInterface
      *
      * @throws NoAceFoundException
      */
-    private function hasSufficientPermissions(AclInterface $acl, array $aces, array $masks, array $sids, $administrativeMode)
+    private function hasSufficientPermissions(AclInterface $acl, array $aces, array $masks, array $sids, bool $administrativeMode): bool
     {
         $firstRejectedAce = null;
 
@@ -185,13 +187,9 @@ class PermissionGrantingStrategy implements PermissionGrantingStrategyInterface
      * Strategy EQUAL:
      * The ACE will be considered applicable when the bitmasks are equal.
      *
-     * @param int $requiredMask
-     *
-     * @return bool
-     *
      * @throws \RuntimeException if the ACE strategy is not supported
      */
-    private function isAceApplicable($requiredMask, EntryInterface $ace)
+    private function isAceApplicable(int $requiredMask, EntryInterface $ace): bool
     {
         $strategy = $ace->getStrategy();
         if (self::ALL === $strategy) {

--- a/Domain/PsrAclCache.php
+++ b/Domain/PsrAclCache.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -28,13 +30,16 @@ class PsrAclCache implements AclCacheInterface
 
     public const PREFIX = 'sf_acl_';
 
-    private $cache;
+    private CacheItemPoolInterface $cache;
 
     /**
      * @throws \InvalidArgumentException When $prefix is empty
      */
-    public function __construct(CacheItemPoolInterface $cache, PermissionGrantingStrategyInterface $permissionGrantingStrategy, string $prefix = self::PREFIX)
-    {
+    public function __construct(
+        CacheItemPoolInterface $cache,
+        PermissionGrantingStrategyInterface $permissionGrantingStrategy,
+        string $prefix = self::PREFIX,
+    ) {
         if ('' === $prefix) {
             throw new \InvalidArgumentException('$prefix cannot be empty.');
         }
@@ -77,9 +82,9 @@ class PsrAclCache implements AclCacheInterface
     /**
      * {@inheritdoc}
      */
-    public function getFromCacheById($aclId): ?AclInterface
+    public function getFromCacheById(int $aclId): ?AclInterface
     {
-        $lookupKey = $this->getAliasKeyForIdentity($aclId);
+        $lookupKey = $this->getAliasKeyForIdentity((string)$aclId);
         $lookupKeyItem = $this->cache->getItem($lookupKey);
         if (!$lookupKeyItem->isHit()) {
             return null;
@@ -129,7 +134,7 @@ class PsrAclCache implements AclCacheInterface
 
         $this->cache->saveDeferred($objectIdentityItem);
 
-        $aliasKey = $this->getAliasKeyForIdentity($acl->getId());
+        $aliasKey = $this->getAliasKeyForIdentity((string)$acl->getId());
         $aliasItem = $this->cache->getItem($aliasKey);
         $aliasItem->set($key);
 

--- a/Domain/RoleSecurityIdentity.php
+++ b/Domain/RoleSecurityIdentity.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -20,19 +22,14 @@ use Symfony\Component\Security\Acl\Model\SecurityIdentityInterface;
  */
 final class RoleSecurityIdentity implements SecurityIdentityInterface
 {
-    private $role;
-
-    public function __construct(string $role)
+    public function __construct(private readonly string $role)
     {
-        $this->role = $role;
     }
 
     /**
      * Returns the role name.
-     *
-     * @return string
      */
-    public function getRole()
+    public function getRole(): string
     {
         return $this->role;
     }
@@ -40,7 +37,7 @@ final class RoleSecurityIdentity implements SecurityIdentityInterface
     /**
      * {@inheritdoc}
      */
-    public function equals(SecurityIdentityInterface $sid)
+    public function equals(SecurityIdentityInterface $sid): bool
     {
         if (!$sid instanceof self) {
             return false;
@@ -53,10 +50,8 @@ final class RoleSecurityIdentity implements SecurityIdentityInterface
      * Returns a textual representation of this security identity.
      *
      * This is solely used for debugging purposes, not to make an equality decision.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return sprintf('RoleSecurityIdentity(%s)', $this->role);
     }

--- a/Domain/UserSecurityIdentity.php
+++ b/Domain/UserSecurityIdentity.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -23,46 +25,36 @@ use Symfony\Component\Security\Core\User\UserInterface;
  */
 final class UserSecurityIdentity implements SecurityIdentityInterface
 {
-    private $username;
-    private $class;
-
     /**
-     * Constructor.
-     *
      * @param string $username the username representation
      * @param string $class    the user's fully qualified class name
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct($username, $class)
-    {
-        if ('' === $username || null === $username) {
+    public function __construct(
+        private readonly string $username,
+        private readonly string $class,
+    ) {
+        if ('' === $username) {
             throw new \InvalidArgumentException('$username must not be empty.');
         }
         if (empty($class)) {
             throw new \InvalidArgumentException('$class must not be empty.');
         }
-
-        $this->username = (string) $username;
-        $this->class = $class;
     }
 
     /**
      * Creates a user security identity from a UserInterface.
-     *
-     * @return UserSecurityIdentity
      */
-    public static function fromAccount(UserInterface $user)
+    public static function fromAccount(UserInterface $user): self
     {
-        return new self(method_exists($user, 'getUserIdentifier') ? $user->getUserIdentifier() : $user->getUsername(), ClassUtils::getRealClass($user));
+        return new self($user->getUserIdentifier(), ClassUtils::getRealClass($user));
     }
 
     /**
      * Creates a user security identity from a TokenInterface.
-     *
-     * @return UserSecurityIdentity
      */
-    public static function fromToken(TokenInterface $token)
+    public static function fromToken(TokenInterface $token): self
     {
         $user = $token->getUser();
 
@@ -70,25 +62,21 @@ final class UserSecurityIdentity implements SecurityIdentityInterface
             return self::fromAccount($user);
         }
 
-        return new self((string) $user, \is_object($user) ? ClassUtils::getRealClass($user) : ClassUtils::getRealClass($token));
+        return new self((string) $user, ClassUtils::getRealClass($token));
     }
 
     /**
      * Returns the username.
-     *
-     * @return string
      */
-    public function getUsername()
+    public function getUsername(): string
     {
         return $this->username;
     }
 
     /**
      * Returns the user's class name.
-     *
-     * @return string
      */
-    public function getClass()
+    public function getClass(): string
     {
         return $this->class;
     }
@@ -96,7 +84,7 @@ final class UserSecurityIdentity implements SecurityIdentityInterface
     /**
      * {@inheritdoc}
      */
-    public function equals(SecurityIdentityInterface $sid)
+    public function equals(SecurityIdentityInterface $sid): bool
     {
         if (!$sid instanceof self) {
             return false;
@@ -110,10 +98,8 @@ final class UserSecurityIdentity implements SecurityIdentityInterface
      * A textual representation of this security identity.
      *
      * This is not used for equality comparison, but only for debugging.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return sprintf('UserSecurityIdentity(%s, %s)', $this->username, $this->class);
     }

--- a/Exception/AclAlreadyExistsException.php
+++ b/Exception/AclAlreadyExistsException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *

--- a/Exception/AclNotFoundException.php
+++ b/Exception/AclNotFoundException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *

--- a/Exception/ConcurrentModificationException.php
+++ b/Exception/ConcurrentModificationException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *

--- a/Exception/Exception.php
+++ b/Exception/Exception.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *

--- a/Exception/InvalidDomainObjectException.php
+++ b/Exception/InvalidDomainObjectException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *

--- a/Exception/NoAceFoundException.php
+++ b/Exception/NoAceFoundException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *

--- a/Exception/NotAllAclsFoundException.php
+++ b/Exception/NotAllAclsFoundException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -25,12 +27,15 @@ use Symfony\Component\Security\Acl\Model\ObjectIdentityInterface;
  */
 class NotAllAclsFoundException extends AclNotFoundException
 {
-    private $partialResult;
+    /**
+     * @var \SplObjectStorage<ObjectIdentityInterface,AclInterface>
+     */
+    private \SplObjectStorage $partialResult;
 
     /**
      * @param \SplObjectStorage<ObjectIdentityInterface,AclInterface> $result
      */
-    public function setPartialResult(\SplObjectStorage $result)
+    public function setPartialResult(\SplObjectStorage $result): void
     {
         $this->partialResult = $result;
     }
@@ -40,7 +45,7 @@ class NotAllAclsFoundException extends AclNotFoundException
      *
      * @return \SplObjectStorage<ObjectIdentityInterface,AclInterface>
      */
-    public function getPartialResult()
+    public function getPartialResult(): \SplObjectStorage
     {
         return $this->partialResult;
     }

--- a/Exception/SidNotLoadedException.php
+++ b/Exception/SidNotLoadedException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *

--- a/Model/AclCacheInterface.php
+++ b/Model/AclCacheInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -23,38 +25,32 @@ interface AclCacheInterface
      *
      * @param string $aclId a serialized primary key
      */
-    public function evictFromCacheById($aclId);
+    public function evictFromCacheById(string $aclId): void;
 
     /**
      * Removes an ACL from the cache.
      *
      * The ACL which is returned, must reference the passed object identity.
      */
-    public function evictFromCacheByIdentity(ObjectIdentityInterface $oid);
+    public function evictFromCacheByIdentity(ObjectIdentityInterface $oid): void;
 
     /**
      * Retrieves an ACL for the given object identity primary key from the cache.
-     *
-     * @param int $aclId
-     *
-     * @return AclInterface|null
      */
-    public function getFromCacheById($aclId);
+    public function getFromCacheById(int $aclId): ?AclInterface;
 
     /**
      * Retrieves an ACL for the given object identity from the cache.
-     *
-     * @return AclInterface|null
      */
-    public function getFromCacheByIdentity(ObjectIdentityInterface $oid);
+    public function getFromCacheByIdentity(ObjectIdentityInterface $oid): ?AclInterface;
 
     /**
      * Stores a new ACL in the cache.
      */
-    public function putInCache(AclInterface $acl);
+    public function putInCache(AclInterface $acl): void;
 
     /**
      * Removes all ACLs from the cache.
      */
-    public function clearCache();
+    public function clearCache(): void;
 }

--- a/Model/AclInterface.php
+++ b/Model/AclInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -33,72 +35,64 @@ interface AclInterface extends \Serializable
      *
      * @return array<int, EntryInterface>
      */
-    public function getClassAces();
+    public function getClassAces(): array;
 
     /**
      * Returns all class-field-based ACEs associated with this ACL.
      *
      * @return array<int, EntryInterface>
      */
-    public function getClassFieldAces(string $field);
+    public function getClassFieldAces(string $field): array;
 
     /**
      * Returns all object-based ACEs associated with this ACL.
      *
      * @return array<int, EntryInterface>
      */
-    public function getObjectAces();
+    public function getObjectAces(): array;
 
     /**
      * Returns all object-field-based ACEs associated with this ACL.
      *
      * @return array<int, EntryInterface>
      */
-    public function getObjectFieldAces(string $field);
+    public function getObjectFieldAces(string $field): array;
 
     /**
      * Returns the object identity associated with this ACL.
-     *
-     * @return ObjectIdentityInterface
      */
-    public function getObjectIdentity();
+    public function getObjectIdentity(): ObjectIdentityInterface;
 
     /**
      * Returns the parent ACL, or null if there is none.
-     *
-     * @return AclInterface|null
      */
-    public function getParentAcl();
+    public function getParentAcl(): self|int|null;
 
     /**
      * Whether this ACL is inheriting ACEs from a parent ACL.
-     *
-     * @return bool
      */
-    public function isEntriesInheriting();
+    public function isEntriesInheriting(): bool;
 
     /**
      * Determines whether field access is granted.
      *
-     * @return bool
+     * @param int[]                       $masks
+     * @param SecurityIdentityInterface[] $securityIdentities
      */
-    public function isFieldGranted(string $field, array $masks, array $securityIdentities, bool $administrativeMode = false);
+    public function isFieldGranted(string $field, array $masks, array $securityIdentities, bool $administrativeMode = false): bool;
 
     /**
      * Determines whether access is granted.
      *
-     * @return bool
+     * @param int[]                       $masks
+     * @param SecurityIdentityInterface[] $securityIdentities
      *
      * @throws NoAceFoundException when no ACE was applicable for this request
      */
-    public function isGranted(array $masks, array $securityIdentities, bool $administrativeMode = false);
+    public function isGranted(array $masks, array $securityIdentities, bool $administrativeMode = false): bool;
 
     /**
      * Whether the ACL has loaded ACEs for all of the passed security identities.
-     *
-     * @param SecurityIdentityInterface|SecurityIdentityInterface[] $securityIdentities
-     *
-     * @return bool
      */
-    public function isSidLoaded($securityIdentities);
+    public function isSidLoaded(SecurityIdentityInterface ...$securityIdentities): bool;
 }

--- a/Model/AclProviderInterface.php
+++ b/Model/AclProviderInterface.php
@@ -23,22 +23,18 @@ interface AclProviderInterface
     /**
      * Retrieves all child object identities from the database.
      *
-     * @param bool $directChildrenOnly
-     *
-     * @return array returns an array of child 'ObjectIdentity's
+     * @return ObjectIdentityInterface[] returns an array of child 'ObjectIdentity's
      */
-    public function findChildren(ObjectIdentityInterface $parentOid, $directChildrenOnly = false);
+    public function findChildren(ObjectIdentityInterface $parentOid, bool $directChildrenOnly = false): array;
 
     /**
      * Returns the ACL that belongs to the given object identity.
      *
      * @param SecurityIdentityInterface[] $sids
      *
-     * @return AclInterface
-     *
      * @throws AclNotFoundException when there is no ACL
      */
-    public function findAcl(ObjectIdentityInterface $oid, array $sids = []);
+    public function findAcl(ObjectIdentityInterface $oid, array $sids = []): AclInterface;
 
     /**
      * Returns the ACLs that belong to the given object identities.
@@ -50,5 +46,5 @@ interface AclProviderInterface
      *
      * @throws AclNotFoundException when we cannot find an ACL for all identities
      */
-    public function findAcls(array $oids, array $sids = []);
+    public function findAcls(array $oids, array $sids = []): \SplObjectStorage;
 }

--- a/Model/AuditLoggerInterface.php
+++ b/Model/AuditLoggerInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -21,8 +23,6 @@ interface AuditLoggerInterface
     /**
      * This method is called whenever access is granted, or denied, and
      * administrative mode is turned off.
-     *
-     * @param bool $granted
      */
-    public function logIfNeeded($granted, EntryInterface $ace);
+    public function logIfNeeded(bool $granted, EntryInterface $ace): void;
 }

--- a/Model/AuditableAclInterface.php
+++ b/Model/AuditableAclInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -21,20 +23,20 @@ interface AuditableAclInterface extends MutableAclInterface
     /**
      * Updates auditing for class-based ACE.
      */
-    public function updateClassAuditing(int $index, bool $auditSuccess, bool $auditFailure);
+    public function updateClassAuditing(int $index, bool $auditSuccess, bool $auditFailure): void;
 
     /**
      * Updates auditing for class-field-based ACE.
      */
-    public function updateClassFieldAuditing(int $index, string $field, bool $auditSuccess, bool $auditFailure);
+    public function updateClassFieldAuditing(int $index, string $field, bool $auditSuccess, bool $auditFailure): void;
 
     /**
      * Updates auditing for object-based ACE.
      */
-    public function updateObjectAuditing(int $index, bool $auditSuccess, bool $auditFailure);
+    public function updateObjectAuditing(int $index, bool $auditSuccess, bool $auditFailure): void;
 
     /**
      * Updates auditing for object-field-based ACE.
      */
-    public function updateObjectFieldAuditing(int $index, string $field, bool $auditSuccess, bool $auditFailure);
+    public function updateObjectFieldAuditing(int $index, string $field, bool $auditSuccess, bool $auditFailure): void;
 }

--- a/Model/AuditableEntryInterface.php
+++ b/Model/AuditableEntryInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -20,15 +22,11 @@ interface AuditableEntryInterface extends EntryInterface
 {
     /**
      * Whether auditing for successful grants is turned on.
-     *
-     * @return bool
      */
-    public function isAuditFailure();
+    public function isAuditFailure(): bool;
 
     /**
      * Whether auditing for successful denies is turned on.
-     *
-     * @return bool
      */
-    public function isAuditSuccess();
+    public function isAuditSuccess(): bool;
 }

--- a/Model/DomainObjectInterface.php
+++ b/Model/DomainObjectInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -22,8 +24,6 @@ interface DomainObjectInterface
 {
     /**
      * Returns a unique identifier for this domain object.
-     *
-     * @return string
      */
-    public function getObjectIdentifier();
+    public function getObjectIdentifier(): string;
 }

--- a/Model/EntryInterface.php
+++ b/Model/EntryInterface.php
@@ -26,43 +26,31 @@ interface EntryInterface extends \Serializable
 {
     /**
      * The ACL this ACE is associated with.
-     *
-     * @return AclInterface
      */
-    public function getAcl();
+    public function getAcl(): ?AclInterface;
 
     /**
      * The primary key of this ACE.
-     *
-     * @return int|null
      */
-    public function getId();
+    public function getId(): ?int;
 
     /**
      * The permission mask of this ACE.
-     *
-     * @return int
      */
-    public function getMask();
+    public function getMask(): int;
 
     /**
      * The security identity associated with this ACE.
-     *
-     * @return SecurityIdentityInterface
      */
-    public function getSecurityIdentity();
+    public function getSecurityIdentity(): SecurityIdentityInterface;
 
     /**
      * The strategy for comparing masks.
-     *
-     * @return string
      */
-    public function getStrategy();
+    public function getStrategy(): string;
 
     /**
      * Returns whether this ACE is granting, or denying.
-     *
-     * @return bool
      */
-    public function isGranting();
+    public function isGranting(): bool;
 }

--- a/Model/FieldEntryInterface.php
+++ b/Model/FieldEntryInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -20,8 +22,6 @@ interface FieldEntryInterface extends EntryInterface
 {
     /**
      * Returns the field used for this entry.
-     *
-     * @return string
      */
-    public function getField();
+    public function getField(): string;
 }

--- a/Model/MutableAclInterface.php
+++ b/Model/MutableAclInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -24,85 +26,83 @@ interface MutableAclInterface extends AclInterface
     /**
      * Deletes a class-based ACE.
      */
-    public function deleteClassAce(int $index);
+    public function deleteClassAce(int $index): void;
 
     /**
      * Deletes a class-field-based ACE.
      */
-    public function deleteClassFieldAce(int $index, string $field);
+    public function deleteClassFieldAce(int $index, string $field): void;
 
     /**
      * Deletes an object-based ACE.
      */
-    public function deleteObjectAce(int $index);
+    public function deleteObjectAce(int $index): void;
 
     /**
      * Deletes an object-field-based ACE.
      */
-    public function deleteObjectFieldAce(int $index, string $field);
+    public function deleteObjectFieldAce(int $index, string $field): void;
 
     /**
      * Returns the primary key of this ACL.
-     *
-     * @return int
      */
-    public function getId();
+    public function getId(): int;
 
     /**
      * Inserts a class-based ACE.
      */
-    public function insertClassAce(SecurityIdentityInterface $sid, int $mask, int $index = 0, bool $granting = true, ?string $strategy = null);
+    public function insertClassAce(SecurityIdentityInterface $sid, int $mask, int $index = 0, bool $granting = true, ?string $strategy = null): void;
 
     /**
      * Inserts a class-field-based ACE.
      */
-    public function insertClassFieldAce(string $field, SecurityIdentityInterface $sid, int $mask, int $index = 0, bool $granting = true, ?string $strategy = null);
+    public function insertClassFieldAce(string $field, SecurityIdentityInterface $sid, int $mask, int $index = 0, bool $granting = true, ?string $strategy = null): void;
 
     /**
      * Inserts an object-based ACE.
      */
-    public function insertObjectAce(SecurityIdentityInterface $sid, int $mask, int $index = 0, bool $granting = true, ?string $strategy = null);
+    public function insertObjectAce(SecurityIdentityInterface $sid, int $mask, int $index = 0, bool $granting = true, ?string $strategy = null): void;
 
     /**
      * Inserts an object-field-based ACE.
      */
-    public function insertObjectFieldAce(string $field, SecurityIdentityInterface $sid, int $mask, int $index = 0, bool $granting = true, ?string $strategy = null);
+    public function insertObjectFieldAce(string $field, SecurityIdentityInterface $sid, int $mask, int $index = 0, bool $granting = true, ?string $strategy = null): void;
 
     /**
      * Sets whether entries are inherited.
      */
-    public function setEntriesInheriting(bool $boolean);
+    public function setEntriesInheriting(bool $boolean): void;
 
     /**
      * Sets the parent ACL.
      */
-    public function setParentAcl(?AclInterface $acl = null);
+    public function setParentAcl(?AclInterface $acl = null): void;
 
     /**
      * Updates a class-based ACE.
      *
      * @param string|null $strategy if null the strategy should not be changed
      */
-    public function updateClassAce(int $index, int $mask, ?string $strategy = null);
+    public function updateClassAce(int $index, int $mask, ?string $strategy = null): void;
 
     /**
      * Updates a class-field-based ACE.
      *
      * @param string|null $strategy if null the strategy should not be changed
      */
-    public function updateClassFieldAce(int $index, string $field, int $mask, ?string $strategy = null);
+    public function updateClassFieldAce(int $index, string $field, int $mask, ?string $strategy = null): void;
 
     /**
      * Updates an object-based ACE.
      *
      * @param string|null $strategy if null the strategy should not be changed
      */
-    public function updateObjectAce(int $index, int $mask, ?string $strategy = null);
+    public function updateObjectAce(int $index, int $mask, ?string $strategy = null): void;
 
     /**
      * Updates an object-field-based ACE.
      *
      * @param string|null $strategy if null the strategy should not be changed
      */
-    public function updateObjectFieldAce(int $index, string $field, int $mask, ?string $strategy = null);
+    public function updateObjectFieldAce(int $index, string $field, int $mask, ?string $strategy = null): void;
 }

--- a/Model/MutableAclProviderInterface.php
+++ b/Model/MutableAclProviderInterface.php
@@ -22,27 +22,23 @@ interface MutableAclProviderInterface extends AclProviderInterface
 {
     /**
      * {@inheritdoc}
-     *
-     * @return MutableAclInterface
      */
-    public function findAcl(ObjectIdentityInterface $oid, array $sids = []);
+    public function findAcl(ObjectIdentityInterface $oid, array $sids = []): AclInterface;
 
     /**
      * {@inheritdoc}
      *
      * @return \SplObjectStorage<ObjectIdentityInterface, MutableAclInterface> mapping the passed object identities to ACLs
      */
-    public function findAcls(array $oids, array $sids = []);
+    public function findAcls(array $oids, array $sids = []): \SplObjectStorage;
 
     /**
      * Creates a new ACL for the given object identity.
      *
-     * @return MutableAclInterface
-     *
      * @throws AclAlreadyExistsException when there already is an ACL for the given
      *                                   object identity
      */
-    public function createAcl(ObjectIdentityInterface $oid);
+    public function createAcl(ObjectIdentityInterface $oid): MutableAclInterface;
 
     /**
      * Deletes the ACL for a given object identity.
@@ -50,7 +46,7 @@ interface MutableAclProviderInterface extends AclProviderInterface
      * This will automatically trigger a delete for any child ACLs. If you don't
      * want child ACLs to be deleted, you will have to set their parent ACL to null.
      */
-    public function deleteAcl(ObjectIdentityInterface $oid);
+    public function deleteAcl(ObjectIdentityInterface $oid): void;
 
     /**
      * Persists any changes which were made to the ACL, or any associated
@@ -58,5 +54,5 @@ interface MutableAclProviderInterface extends AclProviderInterface
      *
      * Changes to parent ACLs are not persisted.
      */
-    public function updateAcl(MutableAclInterface $acl);
+    public function updateAcl(MutableAclInterface $acl): void;
 }

--- a/Model/ObjectIdentityInterface.php
+++ b/Model/ObjectIdentityInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -26,10 +28,8 @@ interface ObjectIdentityInterface
      *
      * Referential Equality: $object1 === $object2
      * Example for Object Equality: $object1->getId() === $object2->getId()
-     *
-     * @return bool
      */
-    public function equals(self $identity);
+    public function equals(self $identity): bool;
 
     /**
      * Obtains a unique identifier for this object. The identifier must not be
@@ -37,12 +37,12 @@ interface ObjectIdentityInterface
      *
      * @return string cannot return null
      */
-    public function getIdentifier();
+    public function getIdentifier(): string;
 
     /**
      * Returns a type for the domain object. Typically, this is the PHP class name.
      *
      * @return string cannot return null
      */
-    public function getType();
+    public function getType(): string;
 }

--- a/Model/ObjectIdentityRetrievalStrategyInterface.php
+++ b/Model/ObjectIdentityRetrievalStrategyInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -20,10 +22,6 @@ interface ObjectIdentityRetrievalStrategyInterface
 {
     /**
      * Retrieves the object identity from a domain object.
-     *
-     * @param object $domainObject
-     *
-     * @return ObjectIdentityInterface
      */
-    public function getObjectIdentity($domainObject);
+    public function getObjectIdentity(object $domainObject): ?ObjectIdentityInterface;
 }

--- a/Model/PermissionGrantingStrategyInterface.php
+++ b/Model/PermissionGrantingStrategyInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -21,19 +23,16 @@ interface PermissionGrantingStrategyInterface
     /**
      * Determines whether access to a domain object is to be granted.
      *
-     * @param bool $administrativeMode
-     *
-     * @return bool
+     * @param int[]                       $masks
+     * @param SecurityIdentityInterface[] $sids
      */
-    public function isGranted(AclInterface $acl, array $masks, array $sids, $administrativeMode = false);
+    public function isGranted(AclInterface $acl, array $masks, array $sids, bool $administrativeMode = false): bool;
 
     /**
      * Determines whether access to a domain object's field is to be granted.
      *
-     * @param string $field
-     * @param bool   $administrativeMode
-     *
-     * @return bool
+     * @param int[]                       $masks
+     * @param SecurityIdentityInterface[] $sids
      */
-    public function isFieldGranted(AclInterface $acl, $field, array $masks, array $sids, $administrativeMode = false);
+    public function isFieldGranted(AclInterface $acl, string $field, array $masks, array $sids, bool $administrativeMode = false): bool;
 }

--- a/Model/SecurityIdentityInterface.php
+++ b/Model/SecurityIdentityInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -24,5 +26,5 @@ interface SecurityIdentityInterface
      * This method is used to compare two security identities in order to
      * not rely on referential equality.
      */
-    public function equals(self $sid);
+    public function equals(self $sid): bool;
 }

--- a/Model/SecurityIdentityRetrievalStrategyInterface.php
+++ b/Model/SecurityIdentityRetrievalStrategyInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -29,5 +31,5 @@ interface SecurityIdentityRetrievalStrategyInterface
      *
      * @return SecurityIdentityInterface[] An array of SecurityIdentityInterface implementations
      */
-    public function getSecurityIdentities(TokenInterface $token);
+    public function getSecurityIdentities(TokenInterface $token): array;
 }

--- a/Permission/AbstractMaskBuilder.php
+++ b/Permission/AbstractMaskBuilder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -16,17 +18,9 @@ namespace Symfony\Component\Security\Acl\Permission;
  */
 abstract class AbstractMaskBuilder implements MaskBuilderInterface
 {
-    /**
-     * @var int
-     */
-    protected $mask;
+    protected int $mask;
 
-    /**
-     * Constructor.
-     *
-     * @param int $mask optional; defaults to 0
-     */
-    public function __construct($mask = 0)
+    public function __construct(int $mask = 0)
     {
         $this->set($mask);
     }
@@ -34,12 +28,8 @@ abstract class AbstractMaskBuilder implements MaskBuilderInterface
     /**
      * {@inheritdoc}
      */
-    public function set($mask)
+    public function set(int $mask): static
     {
-        if (!\is_int($mask)) {
-            throw new \InvalidArgumentException('$mask must be an integer.');
-        }
-
         $this->mask = $mask;
 
         return $this;
@@ -48,7 +38,7 @@ abstract class AbstractMaskBuilder implements MaskBuilderInterface
     /**
      * {@inheritdoc}
      */
-    public function get()
+    public function get(): int
     {
         return $this->mask;
     }
@@ -56,7 +46,7 @@ abstract class AbstractMaskBuilder implements MaskBuilderInterface
     /**
      * {@inheritdoc}
      */
-    public function add($mask)
+    public function add(string|int $mask): static
     {
         $this->mask |= $this->resolveMask($mask);
 
@@ -66,7 +56,7 @@ abstract class AbstractMaskBuilder implements MaskBuilderInterface
     /**
      * {@inheritdoc}
      */
-    public function remove($mask)
+    public function remove(string|int $mask): static
     {
         $this->mask &= ~$this->resolveMask($mask);
 
@@ -76,7 +66,7 @@ abstract class AbstractMaskBuilder implements MaskBuilderInterface
     /**
      * {@inheritdoc}
      */
-    public function reset()
+    public function reset(): static
     {
         $this->mask = 0;
 

--- a/Permission/BasicPermissionMap.php
+++ b/Permission/BasicPermissionMap.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -28,7 +30,10 @@ class BasicPermissionMap implements PermissionMapInterface, MaskBuilderRetrieval
     public const PERMISSION_MASTER = 'MASTER';
     public const PERMISSION_OWNER = 'OWNER';
 
-    protected $map;
+    /**
+     * @var array<string,array<int,int>>
+     */
+    protected array $map;
 
     public function __construct()
     {
@@ -89,10 +94,10 @@ class BasicPermissionMap implements PermissionMapInterface, MaskBuilderRetrieval
     /**
      * {@inheritdoc}
      */
-    public function getMasks($permission, $object)
+    public function getMasks(string $permission, $object): ?array
     {
         if (!isset($this->map[$permission])) {
-            return;
+            return null;
         }
 
         return $this->map[$permission];
@@ -101,7 +106,7 @@ class BasicPermissionMap implements PermissionMapInterface, MaskBuilderRetrieval
     /**
      * {@inheritdoc}
      */
-    public function contains($permission)
+    public function contains(string $permission): bool
     {
         return isset($this->map[$permission]);
     }
@@ -109,7 +114,7 @@ class BasicPermissionMap implements PermissionMapInterface, MaskBuilderRetrieval
     /**
      * {@inheritdoc}
      */
-    public function getMaskBuilder()
+    public function getMaskBuilder(): MaskBuilder
     {
         return new MaskBuilder();
     }

--- a/Permission/MaskBuilder.php
+++ b/Permission/MaskBuilder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -69,10 +71,8 @@ class MaskBuilder extends AbstractMaskBuilder
 
     /**
      * Returns a human-readable representation of the permission.
-     *
-     * @return string
      */
-    public function getPattern()
+    public function getPattern(): string
     {
         $pattern = self::ALL_OFF;
         $length = \strlen($pattern);
@@ -94,22 +94,14 @@ class MaskBuilder extends AbstractMaskBuilder
     /**
      * Returns the code for the passed mask.
      *
-     * @param int $mask
-     *
-     * @return string
-     *
      * @throws \InvalidArgumentException
      * @throws \RuntimeException
      */
-    public static function getCode($mask)
+    public static function getCode(int $mask): string
     {
-        if (!\is_int($mask)) {
-            throw new \InvalidArgumentException('$mask must be an integer.');
-        }
-
         $reflection = new \ReflectionClass(static::class);
         foreach ($reflection->getConstants() as $name => $cMask) {
-            if (0 !== strpos($name, 'MASK_') || $mask !== $cMask) {
+            if (!str_starts_with($name, 'MASK_') || $mask !== $cMask) {
                 continue;
             }
 
@@ -126,13 +118,9 @@ class MaskBuilder extends AbstractMaskBuilder
     /**
      * Returns the mask for the passed code.
      *
-     * @param mixed $code
-     *
-     * @return int
-     *
      * @throws \InvalidArgumentException
      */
-    public function resolveMask($code)
+    public function resolveMask(string|int $code): int
     {
         if (\is_string($code)) {
             if (!\defined($name = sprintf('static::MASK_%s', strtoupper($code)))) {
@@ -140,10 +128,6 @@ class MaskBuilder extends AbstractMaskBuilder
             }
 
             return \constant($name);
-        }
-
-        if (!\is_int($code)) {
-            throw new \InvalidArgumentException('$code must be an integer.');
         }
 
         return $code;

--- a/Permission/MaskBuilderInterface.php
+++ b/Permission/MaskBuilderInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -19,58 +21,38 @@ interface MaskBuilderInterface
     /**
      * Set the mask of this permission.
      *
-     * @param int $mask
-     *
-     * @return MaskBuilderInterface
-     *
      * @throws \InvalidArgumentException if $mask is not an integer
      */
-    public function set($mask);
+    public function set(int $mask): self;
 
     /**
      * Returns the mask of this permission.
-     *
-     * @return int
      */
-    public function get();
+    public function get(): int;
 
     /**
      * Adds a mask to the permission.
      *
-     * @param mixed $mask
-     *
-     * @return MaskBuilderInterface
-     *
      * @throws \InvalidArgumentException
      */
-    public function add($mask);
+    public function add(int $mask): self;
 
     /**
      * Removes a mask from the permission.
      *
-     * @param mixed $mask
-     *
-     * @return MaskBuilderInterface
-     *
      * @throws \InvalidArgumentException
      */
-    public function remove($mask);
+    public function remove(int $mask): self;
 
     /**
      * Resets the PermissionBuilder.
-     *
-     * @return MaskBuilderInterface
      */
-    public function reset();
+    public function reset(): self;
 
     /**
      * Returns the mask for the passed code.
      *
-     * @param mixed $code
-     *
-     * @return int
-     *
      * @throws \InvalidArgumentException
      */
-    public function resolveMask($code);
+    public function resolveMask(string|int $code): int;
 }

--- a/Permission/MaskBuilderRetrievalInterface.php
+++ b/Permission/MaskBuilderRetrievalInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -18,8 +20,6 @@ interface MaskBuilderRetrievalInterface
 {
     /**
      * Returns a new instance of the MaskBuilder used in the permissionMap.
-     *
-     * @return MaskBuilderInterface
      */
-    public function getMaskBuilder();
+    public function getMaskBuilder(): MaskBuilderInterface;
 }

--- a/Permission/PermissionMapInterface.php
+++ b/Permission/PermissionMapInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -24,19 +26,12 @@ interface PermissionMapInterface
      * The security identity must have been granted access to at least one of
      * these bitmasks.
      *
-     * @param string $permission
-     * @param object $object
-     *
-     * @return array|null may return null if permission/object combination is not supported
+     * @return int[]|null may return null if permission/object combination is not supported
      */
-    public function getMasks($permission, $object);
+    public function getMasks(string $permission, $object): ?array;
 
     /**
      * Whether this map contains the given permission.
-     *
-     * @param string $permission
-     *
-     * @return bool
      */
-    public function contains($permission);
+    public function contains(string $permission): bool;
 }

--- a/Tests/Dbal/AclProviderBenchmarkTest.php
+++ b/Tests/Dbal/AclProviderBenchmarkTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *

--- a/Tests/Dbal/AclProviderTest.php
+++ b/Tests/Dbal/AclProviderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *

--- a/Tests/Dbal/MutableAclProviderTest.php
+++ b/Tests/Dbal/MutableAclProviderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -40,7 +42,7 @@ class MutableAclProviderTest extends TestCase
 
     public static function assertAceEquals(EntryInterface $a, EntryInterface $b)
     {
-        self::assertInstanceOf(\get_class($a), $b);
+        self::assertInstanceOf($a::class, $b);
 
         foreach (['getId', 'getMask', 'getStrategy', 'isGranting'] as $getter) {
             self::assertSame($a->$getter(), $b->$getter());

--- a/Tests/Domain/AclTest.php
+++ b/Tests/Domain/AclTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -288,17 +290,17 @@ class AclTest extends TestCase
 
         $this->assertTrue($acl->isSidLoaded(new UserSecurityIdentity('foo', 'Foo')));
         $this->assertTrue($acl->isSidLoaded(new UserSecurityIdentity('johannes', 'Bar')));
-        $this->assertTrue($acl->isSidLoaded([
+        $this->assertTrue($acl->isSidLoaded(
             new UserSecurityIdentity('foo', 'Foo'),
             new UserSecurityIdentity('johannes', 'Bar'),
-        ]));
+        ));
         $this->assertFalse($acl->isSidLoaded(new RoleSecurityIdentity('ROLE_FOO')));
         $this->assertFalse($acl->isSidLoaded(new UserSecurityIdentity('schmittjoh@gmail.com', 'Moo')));
-        $this->assertFalse($acl->isSidLoaded([
+        $this->assertFalse($acl->isSidLoaded(
             new UserSecurityIdentity('foo', 'Foo'),
             new UserSecurityIdentity('johannes', 'Bar'),
             new RoleSecurityIdentity('ROLE_FOO'),
-        ]));
+        ));
     }
 
     /**

--- a/Tests/Domain/AuditLoggerTest.php
+++ b/Tests/Domain/AuditLoggerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *

--- a/Tests/Domain/DoctrineAclCacheTest.php
+++ b/Tests/Domain/DoctrineAclCacheTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -37,8 +39,6 @@ class DoctrineAclCacheTest extends TestCase
     public function getEmptyValue()
     {
         return [
-            [null],
-            [false],
             [''],
         ];
     }

--- a/Tests/Domain/EntryTest.php
+++ b/Tests/Domain/EntryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *

--- a/Tests/Domain/FieldEntryTest.php
+++ b/Tests/Domain/FieldEntryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *

--- a/Tests/Domain/ObjectIdentityRetrievalStrategyTest.php
+++ b/Tests/Domain/ObjectIdentityRetrievalStrategyTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -18,7 +20,7 @@ class ObjectIdentityRetrievalStrategyTest extends \PHPUnit\Framework\TestCase
     public function testGetObjectIdentityReturnsNullForInvalidDomainObject()
     {
         $strategy = new ObjectIdentityRetrievalStrategy();
-        $this->assertNull($strategy->getObjectIdentity('foo'));
+        $this->assertNull($strategy->getObjectIdentity(new \stdClass()));
     }
 
     public function testGetObjectIdentity()
@@ -28,7 +30,7 @@ class ObjectIdentityRetrievalStrategyTest extends \PHPUnit\Framework\TestCase
         $objectIdentity = $strategy->getObjectIdentity($domainObject);
 
         $this->assertEquals($domainObject->getId(), $objectIdentity->getIdentifier());
-        $this->assertEquals(\get_class($domainObject), $objectIdentity->getType());
+        $this->assertEquals($domainObject::class, $objectIdentity->getType());
     }
 }
 

--- a/Tests/Domain/ObjectIdentityTest.php
+++ b/Tests/Domain/ObjectIdentityTest.php
@@ -35,8 +35,8 @@ namespace Symfony\Component\Security\Acl\Tests\Domain
 
         public function testFromDomainObjectPrefersInterfaceOverGetId()
         {
-            $domainObject = new class() implements DomainObjectInterface {
-                public function getObjectIdentifier()
+            $domainObject = new class implements DomainObjectInterface {
+                public function getObjectIdentifier(): string
                 {
                     return 'getObjectIdentifier()';
                 }

--- a/Tests/Domain/PermissionGrantingStrategyTest.php
+++ b/Tests/Domain/PermissionGrantingStrategyTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -166,7 +168,7 @@ class PermissionGrantingStrategyTest extends TestCase
             ['all', 1 << 0 | 1 << 1, 1 << 0, true],
             ['all', 1 << 0 | 1 << 1, 1 << 2, false],
             ['all', 1 << 0 | 1 << 10, 1 << 0 | 1 << 10, true],
-            ['all', 1 << 0 | 1 << 1, 1 << 0 | 1 << 1 || 1 << 2, false],
+            ['all', 1 << 0 | 1 << 1, 1 << 0 | 1 << 1 | 1 << 2, false],
             ['any', 1 << 0 | 1 << 1, 1 << 0, true],
             ['any', 1 << 0 | 1 << 1, 1 << 0 | 1 << 2, true],
             ['any', 1 << 0 | 1 << 1, 1 << 2, false],

--- a/Tests/Domain/PsrAclCacheTest.php
+++ b/Tests/Domain/PsrAclCacheTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *

--- a/Tests/Domain/RoleSecurityIdentityTest.php
+++ b/Tests/Domain/RoleSecurityIdentityTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *

--- a/Tests/Domain/SecurityIdentityRetrievalStrategyTest.php
+++ b/Tests/Domain/SecurityIdentityRetrievalStrategyTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *

--- a/Tests/Domain/UserSecurityIdentityTest.php
+++ b/Tests/Domain/UserSecurityIdentityTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *

--- a/Tests/Permission/BasicPermissionMapTest.php
+++ b/Tests/Permission/BasicPermissionMapTest.php
@@ -18,6 +18,6 @@ class BasicPermissionMapTest extends \PHPUnit\Framework\TestCase
     public function testGetMasksReturnsNullWhenNotSupportedMask()
     {
         $map = new BasicPermissionMap();
-        $this->assertNull($map->getMasks('IS_AUTHENTICATED_REMEMBERED', null));
+        $this->assertNull($map->getMasks('IS_AUTHENTICATED_REMEMBERED', new \stdClass()));
     }
 }

--- a/Tests/Permission/MaskBuilderTest.php
+++ b/Tests/Permission/MaskBuilderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -20,7 +22,7 @@ class MaskBuilderTest extends \PHPUnit\Framework\TestCase
      */
     public function testConstructorWithNonInteger($invalidMask)
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(\TypeError::class);
 
         new MaskBuilder($invalidMask);
     }

--- a/Tests/Voter/AclVoterTest.php
+++ b/Tests/Voter/AclVoterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *

--- a/Util/ClassUtils.php
+++ b/Util/ClassUtils.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -47,14 +49,10 @@ final class ClassUtils
 
     /**
      * Gets the real class name of a class name that could be a proxy.
-     *
-     * @param string|object $object
-     *
-     * @return string
      */
-    public static function getRealClass($object)
+    public static function getRealClass(object|string $object): string
     {
-        $class = \is_object($object) ? \get_class($object) : $object;
+        $class = \is_object($object) ? $object::class : $object;
 
         if (class_exists(DoctrineClassUtils::class)) {
             return DoctrineClassUtils::getRealClass($class);

--- a/Voter/AclVoter.php
+++ b/Voter/AclVoter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -28,6 +30,11 @@ if (class_exists(\Symfony\Component\Security\Core\Security::class)) {
      */
     trait AclVoterTrait
     {
+        /**
+         * @param mixed[] $attributes
+         *
+         * @return int<-1,1>
+         */
         public function vote(TokenInterface $token, $subject, array $attributes)
         {
             return $this->doVote($token, $subject, $attributes);
@@ -39,6 +46,11 @@ if (class_exists(\Symfony\Component\Security\Core\Security::class)) {
      */
     trait AclVoterTrait
     {
+        /**
+         * @param mixed[] $attributes
+         *
+         * @return int<-1,1>
+         */
         public function vote(TokenInterface $token, mixed $subject, array $attributes): int
         {
             return $this->doVote($token, $subject, $attributes);
@@ -55,29 +67,25 @@ class AclVoter implements VoterInterface
 {
     use AclVoterTrait;
 
-    private $aclProvider;
-    private $permissionMap;
-    private $objectIdentityRetrievalStrategy;
-    private $securityIdentityRetrievalStrategy;
-    private $allowIfObjectIdentityUnavailable;
-    private $logger;
-
-    public function __construct(AclProviderInterface $aclProvider, ObjectIdentityRetrievalStrategyInterface $oidRetrievalStrategy, SecurityIdentityRetrievalStrategyInterface $sidRetrievalStrategy, PermissionMapInterface $permissionMap, LoggerInterface $logger = null, $allowIfObjectIdentityUnavailable = true)
-    {
-        $this->aclProvider = $aclProvider;
-        $this->permissionMap = $permissionMap;
-        $this->objectIdentityRetrievalStrategy = $oidRetrievalStrategy;
-        $this->securityIdentityRetrievalStrategy = $sidRetrievalStrategy;
-        $this->logger = $logger;
-        $this->allowIfObjectIdentityUnavailable = $allowIfObjectIdentityUnavailable;
+    public function __construct(
+        private readonly AclProviderInterface $aclProvider,
+        private readonly ObjectIdentityRetrievalStrategyInterface $objectIdentityRetrievalStrategy,
+        private readonly SecurityIdentityRetrievalStrategyInterface $securityIdentityRetrievalStrategy,
+        private readonly PermissionMapInterface $permissionMap,
+        private readonly ?LoggerInterface $logger = null,
+        private readonly bool $allowIfObjectIdentityUnavailable = true,
+    ) {
     }
 
-    public function supportsAttribute($attribute)
+    public function supportsAttribute(mixed $attribute): bool
     {
         return \is_string($attribute) && $this->permissionMap->contains($attribute);
     }
 
-    private function doVote(TokenInterface $token, $subject, array $attributes): int
+    /**
+     * @param mixed[] $attributes
+     */
+    private function doVote(TokenInterface $token, mixed $subject, array $attributes): int
     {
         foreach ($attributes as $attribute) {
             if (!$this->supportsAttribute($attribute)) {
@@ -161,12 +169,8 @@ class AclVoter implements VoterInterface
     /**
      * You can override this method when writing a voter for a specific domain
      * class.
-     *
-     * @param string $class The class name
-     *
-     * @return bool
      */
-    public function supportsClass($class)
+    public function supportsClass(string $class): bool
     {
         return true;
     }

--- a/Voter/FieldVote.php
+++ b/Voter/FieldVote.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -19,21 +21,18 @@ namespace Symfony\Component\Security\Acl\Voter;
  */
 class FieldVote
 {
-    private $domainObject;
-    private $field;
-
-    public function __construct($domainObject, $field)
-    {
-        $this->domainObject = $domainObject;
-        $this->field = $field;
+    public function __construct(
+        private readonly object $domainObject,
+        private readonly string $field,
+    ) {
     }
 
-    public function getDomainObject()
+    public function getDomainObject(): object
     {
         return $this->domainObject;
     }
 
-    public function getField()
+    public function getField(): string
     {
         return $this->field;
     }

--- a/composer.json
+++ b/composer.json
@@ -16,17 +16,17 @@
         }
     ],
     "require": {
-        "php": ">=7.2.5",
-        "symfony/security-core": "^4.4|^5.0|^6.0|^7.0"
+        "php": ">=8.1.0",
+        "symfony/security-core": "^6.4|^7.0"
     },
     "require-dev": {
-        "symfony/cache": "^4.4|^5.0|^6.0|^7.0",
-        "symfony/finder": "^4.4|^5.0|^6.0|^7.0",
-        "symfony/phpunit-bridge": "^5.2|^6.0|^7.0",
+        "symfony/cache": "^6.4|^7.0",
+        "symfony/finder": "^6.4|^7.0",
+        "symfony/phpunit-bridge": "^6.4|^7.0",
         "doctrine/cache": "^1.11|^2.0",
         "doctrine/common": "^2.2|^3",
-        "doctrine/persistence": "^1.3.3|^2|^3",
-        "doctrine/dbal": "^2.13.1|^3.1",
+        "doctrine/persistence": "^2|^3",
+        "doctrine/dbal": "^3.1",
         "psr/log": "^1|^2|^3"
     },
     "autoload": {
@@ -37,7 +37,7 @@
     },
     "conflict": {
         "doctrine/cache": "<1.11",
-        "doctrine/dbal": "<2.13.1|~3.0.0"
+        "doctrine/dbal": "~3.0.0"
     },
     "extra": {
         "branch-alias": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,37 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
-         failOnRisky="true"
-         failOnWarning="true"
->
-    <php>
-        <ini name="error_reporting" value="-1" />
-    </php>
-
-    <testsuites>
-        <testsuite name="Symfony Security Component ACL Test Suite">
-            <directory>./Tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Resources</directory>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-    <groups>
-        <exclude>
-            <group>benchmark</group>
-        </exclude>
-    </groups>
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
-    </listeners>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php" failOnRisky="true" failOnWarning="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Resources</directory>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <ini name="error_reporting" value="-1"/>
+  </php>
+  <testsuites>
+    <testsuite name="Symfony Security Component ACL Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
+  <groups>
+    <exclude>
+      <group>benchmark</group>
+    </exclude>
+  </groups>
+  <listeners>
+    <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+  </listeners>
 </phpunit>


### PR DESCRIPTION
This change raises the minimum php version to 8.1, enabling the usage of these syntax features:

- property type declarations
- constructor property promotions
- readonly class properties

This change also raises the minimum required versions of symfony/* packages as all supported packages of symfony require php 8.1

This change also drops support for doctrine/dbal:^2 to ease the transition to doctrine/dbal:^4 in the future.

Last but not least, phpunit/phpunit:^9.5 is required to run tests.