### PR TITLE
Add Doctrine DBAL 4 and Persistence 4 compatibility

### DIFF
--- a/Dbal/MutableAclProvider.php
+++ b/Dbal/MutableAclProvider.php
@@ -162,11 +162,9 @@ class MutableAclProvider extends AclProvider implements MutableAclProviderInterf
      * @param mixed  $oldValue
      * @param mixed  $newValue
      *
-     * @return void
-     *
      * @throws \InvalidArgumentException
      */
-    public function propertyChanged($sender, $propertyName, $oldValue, $newValue)
+    public function propertyChanged($sender, $propertyName, $oldValue, $newValue): void
     {
         if (!$sender instanceof MutableAclInterface && !$sender instanceof EntryInterface) {
             throw new \InvalidArgumentException('$sender must be an instance of MutableAclInterface, or EntryInterface.');

--- a/Dbal/Schema.php
+++ b/Dbal/Schema.php
@@ -94,9 +94,9 @@ final class Schema extends BaseSchema
         $table->addUniqueIndex(['class_id', 'object_identity_id', 'field_name', 'ace_order']);
         $table->addIndex(['class_id', 'object_identity_id', 'security_identity_id']);
 
-        $table->addForeignKeyConstraint($this->getTable($this->options['class_table_name']), ['class_id'], ['id'], ['onDelete' => 'CASCADE', 'onUpdate' => 'CASCADE']);
-        $table->addForeignKeyConstraint($this->getTable($this->options['oid_table_name']), ['object_identity_id'], ['id'], ['onDelete' => 'CASCADE', 'onUpdate' => 'CASCADE']);
-        $table->addForeignKeyConstraint($this->getTable($this->options['sid_table_name']), ['security_identity_id'], ['id'], ['onDelete' => 'CASCADE', 'onUpdate' => 'CASCADE']);
+        $table->addForeignKeyConstraint($this->options['class_table_name'], ['class_id'], ['id'], ['onDelete' => 'CASCADE', 'onUpdate' => 'CASCADE']);
+        $table->addForeignKeyConstraint($this->options['oid_table_name'], ['object_identity_id'], ['id'], ['onDelete' => 'CASCADE', 'onUpdate' => 'CASCADE']);
+        $table->addForeignKeyConstraint($this->options['sid_table_name'], ['security_identity_id'], ['id'], ['onDelete' => 'CASCADE', 'onUpdate' => 'CASCADE']);
     }
 
     /**
@@ -116,7 +116,7 @@ final class Schema extends BaseSchema
         $table->addUniqueIndex(['object_identifier', 'class_id']);
         $table->addIndex(['parent_object_identity_id']);
 
-        $table->addForeignKeyConstraint($table, ['parent_object_identity_id'], ['id']);
+        $table->addForeignKeyConstraint($table->getName(), ['parent_object_identity_id'], ['id']);
     }
 
     /**
@@ -137,8 +137,8 @@ final class Schema extends BaseSchema
             // MS SQL Server does not support recursive cascading
             $action = 'NO ACTION';
         }
-        $table->addForeignKeyConstraint($oidTable, ['object_identity_id'], ['id'], ['onDelete' => $action, 'onUpdate' => $action]);
-        $table->addForeignKeyConstraint($oidTable, ['ancestor_id'], ['id'], ['onDelete' => $action, 'onUpdate' => $action]);
+        $table->addForeignKeyConstraint($oidTable->getName(), ['object_identity_id'], ['id'], ['onDelete' => $action, 'onUpdate' => $action]);
+        $table->addForeignKeyConstraint($oidTable->getName(), ['ancestor_id'], ['id'], ['onDelete' => $action, 'onUpdate' => $action]);
     }
 
     /**

--- a/Dbal/Schema.php
+++ b/Dbal/Schema.php
@@ -67,7 +67,23 @@ final class Schema extends BaseSchema
         $table = $this->createTable($this->options['class_table_name']);
         $table->addColumn('id', 'integer', ['unsigned' => true, 'autoincrement' => true]);
         $table->addColumn('class_type', 'string', ['length' => 200]);
-        $table->setPrimaryKey(['id']);
+
+        /*
+         * DBAL 4+ uses addPrimaryKeyConstraint() with PrimaryKeyConstraint objects,
+         * while DBAL 3 uses setPrimaryKey() with column name arrays.
+         * Fully qualified class names are used to avoid importing DBAL 4-only classes.
+         */
+        if (method_exists($table, 'addPrimaryKeyConstraint')) {
+            $table->addPrimaryKeyConstraint(
+                \Doctrine\DBAL\Schema\PrimaryKeyConstraint::editor()
+                    ->setColumnNames(
+                        \Doctrine\DBAL\Schema\Name\UnqualifiedName::unquoted('id')
+                    )
+                    ->create()
+            );
+        } else {
+            $table->setPrimaryKey(['id']);
+        }
         $table->addUniqueIndex(['class_type']);
     }
 
@@ -90,7 +106,22 @@ final class Schema extends BaseSchema
         $table->addColumn('audit_success', 'boolean');
         $table->addColumn('audit_failure', 'boolean');
 
-        $table->setPrimaryKey(['id']);
+        /*
+         * DBAL 4+ uses addPrimaryKeyConstraint() with PrimaryKeyConstraint objects,
+         * while DBAL 3 uses setPrimaryKey() with column name arrays.
+         * Fully qualified class names are used to avoid importing DBAL 4-only classes.
+         */
+        if (method_exists($table, 'addPrimaryKeyConstraint')) {
+            $table->addPrimaryKeyConstraint(
+                \Doctrine\DBAL\Schema\PrimaryKeyConstraint::editor()
+                    ->setColumnNames(
+                        \Doctrine\DBAL\Schema\Name\UnqualifiedName::unquoted('id')
+                    )
+                    ->create()
+            );
+        } else {
+            $table->setPrimaryKey(['id']);
+        }
         $table->addUniqueIndex(['class_id', 'object_identity_id', 'field_name', 'ace_order']);
         $table->addIndex(['class_id', 'object_identity_id', 'security_identity_id']);
 
@@ -112,11 +143,32 @@ final class Schema extends BaseSchema
         $table->addColumn('parent_object_identity_id', 'integer', ['unsigned' => true, 'notnull' => false]);
         $table->addColumn('entries_inheriting', 'boolean');
 
-        $table->setPrimaryKey(['id']);
+        /*
+         * DBAL 4+ uses addPrimaryKeyConstraint() with PrimaryKeyConstraint objects,
+         * while DBAL 3 uses setPrimaryKey() with column name arrays.
+         * Fully qualified class names are used to avoid importing DBAL 4-only classes.
+         */
+        if (method_exists($table, 'addPrimaryKeyConstraint')) {
+            $table->addPrimaryKeyConstraint(
+                \Doctrine\DBAL\Schema\PrimaryKeyConstraint::editor()
+                    ->setColumnNames(
+                        \Doctrine\DBAL\Schema\Name\UnqualifiedName::unquoted('id')
+                    )
+                    ->create()
+            );
+        } else {
+            $table->setPrimaryKey(['id']);
+        }
         $table->addUniqueIndex(['object_identifier', 'class_id']);
         $table->addIndex(['parent_object_identity_id']);
 
-        $table->addForeignKeyConstraint($table->getName(), ['parent_object_identity_id'], ['id']);
+        if (method_exists($table, 'getObjectName')) {
+            $tableName = $table->getObjectName()->toString();
+        } else {
+            $tableName = $table->getName();
+        }
+
+        $table->addForeignKeyConstraint($tableName, ['parent_object_identity_id'], ['id']);
     }
 
     /**
@@ -129,7 +181,23 @@ final class Schema extends BaseSchema
         $table->addColumn('object_identity_id', 'integer', ['unsigned' => true]);
         $table->addColumn('ancestor_id', 'integer', ['unsigned' => true]);
 
-        $table->setPrimaryKey(['object_identity_id', 'ancestor_id']);
+        /*
+         * DBAL 4+ uses addPrimaryKeyConstraint() with PrimaryKeyConstraint objects,
+         * while DBAL 3 uses setPrimaryKey() with column name arrays.
+         * Fully qualified class names are used to avoid importing DBAL 4-only classes.
+         */
+        if (method_exists($table, 'addPrimaryKeyConstraint')) {
+            $table->addPrimaryKeyConstraint(
+                \Doctrine\DBAL\Schema\PrimaryKeyConstraint::editor()
+                    ->setColumnNames(
+                        \Doctrine\DBAL\Schema\Name\UnqualifiedName::unquoted('object_identity_id'),
+                        \Doctrine\DBAL\Schema\Name\UnqualifiedName::unquoted('ancestor_id')
+                    )
+                    ->create()
+            );
+        } else {
+            $table->setPrimaryKey(['object_identity_id', 'ancestor_id']);
+        }
 
         $oidTable = $this->getTable($this->options['oid_table_name']);
         $action = 'CASCADE';
@@ -137,8 +205,14 @@ final class Schema extends BaseSchema
             // MS SQL Server does not support recursive cascading
             $action = 'NO ACTION';
         }
-        $table->addForeignKeyConstraint($oidTable->getName(), ['object_identity_id'], ['id'], ['onDelete' => $action, 'onUpdate' => $action]);
-        $table->addForeignKeyConstraint($oidTable->getName(), ['ancestor_id'], ['id'], ['onDelete' => $action, 'onUpdate' => $action]);
+
+        if (method_exists($oidTable, 'getObjectName')) {
+            $oidTableName = $oidTable->getObjectName()->toString();
+        } else {
+            $oidTableName = $oidTable->getName();
+        }
+        $table->addForeignKeyConstraint($oidTableName, ['object_identity_id'], ['id'], ['onDelete' => $action, 'onUpdate' => $action]);
+        $table->addForeignKeyConstraint($oidTableName, ['ancestor_id'], ['id'], ['onDelete' => $action, 'onUpdate' => $action]);
     }
 
     /**
@@ -152,7 +226,22 @@ final class Schema extends BaseSchema
         $table->addColumn('identifier', 'string', ['length' => 200]);
         $table->addColumn('username', 'boolean');
 
-        $table->setPrimaryKey(['id']);
+        /*
+         * DBAL 4+ uses addPrimaryKeyConstraint() with PrimaryKeyConstraint objects,
+         * while DBAL 3 uses setPrimaryKey() with column name arrays.
+         * Fully qualified class names are used to avoid importing DBAL 4-only classes.
+         */
+        if (method_exists($table, 'addPrimaryKeyConstraint')) {
+            $table->addPrimaryKeyConstraint(
+                \Doctrine\DBAL\Schema\PrimaryKeyConstraint::editor()
+                    ->setColumnNames(
+                        \Doctrine\DBAL\Schema\Name\UnqualifiedName::unquoted('id')
+                    )
+                    ->create()
+            );
+        } else {
+            $table->setPrimaryKey(['id']);
+        }
         $table->addUniqueIndex(['identifier', 'username']);
     }
 

--- a/Dbal/Schema.php
+++ b/Dbal/Schema.php
@@ -68,10 +68,8 @@ final class Schema extends BaseSchema
         $table->addColumn('id', 'integer', ['unsigned' => true, 'autoincrement' => true]);
         $table->addColumn('class_type', 'string', ['length' => 200]);
 
-        /*
-         * DBAL 4+ uses addPrimaryKeyConstraint() with PrimaryKeyConstraint objects,
-         * while DBAL 3 uses setPrimaryKey() with column name arrays.
-         * Fully qualified class names are used to avoid importing DBAL 4-only classes.
+        /**
+         * @psalm-suppress RedundantCondition Since we are compatibles with DBAL 3 and 4, we need to check if the method exists
          */
         if (method_exists($table, 'addPrimaryKeyConstraint')) {
             $table->addPrimaryKeyConstraint(
@@ -106,10 +104,8 @@ final class Schema extends BaseSchema
         $table->addColumn('audit_success', 'boolean');
         $table->addColumn('audit_failure', 'boolean');
 
-        /*
-         * DBAL 4+ uses addPrimaryKeyConstraint() with PrimaryKeyConstraint objects,
-         * while DBAL 3 uses setPrimaryKey() with column name arrays.
-         * Fully qualified class names are used to avoid importing DBAL 4-only classes.
+        /**
+         * @psalm-suppress RedundantCondition Since we are compatibles with DBAL 3 and 4, we need to check if the method exists
          */
         if (method_exists($table, 'addPrimaryKeyConstraint')) {
             $table->addPrimaryKeyConstraint(
@@ -135,7 +131,8 @@ final class Schema extends BaseSchema
      */
     protected function addObjectIdentitiesTable()
     {
-        $table = $this->createTable($this->options['oid_table_name']);
+        $tableName = $this->options['oid_table_name'];
+        $table = $this->createTable($tableName);
 
         $table->addColumn('id', 'integer', ['unsigned' => true, 'autoincrement' => true]);
         $table->addColumn('class_id', 'integer', ['unsigned' => true]);
@@ -143,10 +140,8 @@ final class Schema extends BaseSchema
         $table->addColumn('parent_object_identity_id', 'integer', ['unsigned' => true, 'notnull' => false]);
         $table->addColumn('entries_inheriting', 'boolean');
 
-        /*
-         * DBAL 4+ uses addPrimaryKeyConstraint() with PrimaryKeyConstraint objects,
-         * while DBAL 3 uses setPrimaryKey() with column name arrays.
-         * Fully qualified class names are used to avoid importing DBAL 4-only classes.
+        /**
+         * @psalm-suppress RedundantCondition Since we are compatibles with DBAL 3 and 4, we need to check if the method exists
          */
         if (method_exists($table, 'addPrimaryKeyConstraint')) {
             $table->addPrimaryKeyConstraint(
@@ -162,12 +157,6 @@ final class Schema extends BaseSchema
         $table->addUniqueIndex(['object_identifier', 'class_id']);
         $table->addIndex(['parent_object_identity_id']);
 
-        if (method_exists($table, 'getObjectName')) {
-            $tableName = $table->getObjectName()->toString();
-        } else {
-            $tableName = $table->getName();
-        }
-
         $table->addForeignKeyConstraint($tableName, ['parent_object_identity_id'], ['id']);
     }
 
@@ -181,10 +170,8 @@ final class Schema extends BaseSchema
         $table->addColumn('object_identity_id', 'integer', ['unsigned' => true]);
         $table->addColumn('ancestor_id', 'integer', ['unsigned' => true]);
 
-        /*
-         * DBAL 4+ uses addPrimaryKeyConstraint() with PrimaryKeyConstraint objects,
-         * while DBAL 3 uses setPrimaryKey() with column name arrays.
-         * Fully qualified class names are used to avoid importing DBAL 4-only classes.
+        /**
+         * @psalm-suppress RedundantCondition Since we are compatibles with DBAL 3 and 4, we need to check if the method exists
          */
         if (method_exists($table, 'addPrimaryKeyConstraint')) {
             $table->addPrimaryKeyConstraint(
@@ -199,18 +186,13 @@ final class Schema extends BaseSchema
             $table->setPrimaryKey(['object_identity_id', 'ancestor_id']);
         }
 
-        $oidTable = $this->getTable($this->options['oid_table_name']);
+        $oidTableName = $this->options['oid_table_name'];
         $action = 'CASCADE';
         if ($this->platform instanceof SQLServerPlatform) {
             // MS SQL Server does not support recursive cascading
             $action = 'NO ACTION';
         }
 
-        if (method_exists($oidTable, 'getObjectName')) {
-            $oidTableName = $oidTable->getObjectName()->toString();
-        } else {
-            $oidTableName = $oidTable->getName();
-        }
         $table->addForeignKeyConstraint($oidTableName, ['object_identity_id'], ['id'], ['onDelete' => $action, 'onUpdate' => $action]);
         $table->addForeignKeyConstraint($oidTableName, ['ancestor_id'], ['id'], ['onDelete' => $action, 'onUpdate' => $action]);
     }
@@ -226,10 +208,8 @@ final class Schema extends BaseSchema
         $table->addColumn('identifier', 'string', ['length' => 200]);
         $table->addColumn('username', 'boolean');
 
-        /*
-         * DBAL 4+ uses addPrimaryKeyConstraint() with PrimaryKeyConstraint objects,
-         * while DBAL 3 uses setPrimaryKey() with column name arrays.
-         * Fully qualified class names are used to avoid importing DBAL 4-only classes.
+        /**
+         * @psalm-suppress RedundantCondition Since we are compatibles with DBAL 3 and 4, we need to check if the method exists
          */
         if (method_exists($table, 'addPrimaryKeyConstraint')) {
             $table->addPrimaryKeyConstraint(

--- a/Domain/Acl.php
+++ b/Domain/Acl.php
@@ -64,10 +64,8 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
 
     /**
      * Adds a property changed listener.
-     *
-     * @return void
      */
-    public function addPropertyChangedListener(PropertyChangedListener $listener)
+    public function addPropertyChangedListener(PropertyChangedListener $listener): void
     {
         $this->listeners[] = $listener;
     }

--- a/Tests/Dbal/MutableAclProviderTest.php
+++ b/Tests/Dbal/MutableAclProviderTest.php
@@ -538,7 +538,12 @@ class MutableAclProviderTest extends TestCase
             ],
             $configuration
         );
-        $this->connection->setNestTransactionsWithSavepoints(true);
+
+        // DBAL 3 supports nested transactions with savepoints, removed in DBAL 4
+        // In DBAL 4, Connection implements ServerVersionProvider
+        if (!$this->connection instanceof \Doctrine\DBAL\ServerVersionProvider) {
+            $this->connection->setNestTransactionsWithSavepoints(true);
+        }
 
         // import the schema
         $schema = new Schema($this->getOptions());

--- a/Tests/Dbal/MutableAclProviderTest.php
+++ b/Tests/Dbal/MutableAclProviderTest.php
@@ -263,7 +263,7 @@ class MutableAclProviderTest extends TestCase
         ;
         $con
             ->expects($this->never())
-            ->method('executeUpdate')
+            ->method('executeStatement')
         ;
 
         $provider = new MutableAclProvider($con, new PermissionGrantingStrategy(), []);

--- a/Tests/Dbal/MutableAclProviderTest.php
+++ b/Tests/Dbal/MutableAclProviderTest.php
@@ -538,6 +538,7 @@ class MutableAclProviderTest extends TestCase
             ],
             $configuration
         );
+        $this->connection->setNestTransactionsWithSavepoints(true);
 
         // import the schema
         $schema = new Schema($this->getOptions());

--- a/Tests/Dbal/MutableAclProviderTest.php
+++ b/Tests/Dbal/MutableAclProviderTest.php
@@ -538,7 +538,6 @@ class MutableAclProviderTest extends TestCase
             ],
             $configuration
         );
-        $this->connection->setNestTransactionsWithSavepoints(true);
 
         // import the schema
         $schema = new Schema($this->getOptions());

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
         "symfony/phpunit-bridge": "^5.2|^6.0|^7.0|^8.0",
         "doctrine/cache": "^1.11|^2.0",
         "doctrine/common": "^2.2|^3",
-        "doctrine/persistence": "^1.3.3|^2|^3",
-        "doctrine/dbal": "^2.13.1|^3.1",
+        "doctrine/persistence": "^1.3.3|^2|^3|^4",
+        "doctrine/dbal": "^2.13.1|^3.1|^4",
         "psr/log": "^1|^2|^3"
     },
     "autoload": {


### PR DESCRIPTION
This commit adds support for doctrine/dbal ^4 and doctrine/persistence ^4.

Changes:
- Updated composer.json to allow doctrine/dbal ^4 and doctrine/persistence ^4
- Added required return type annotations `: void` to methods implementing interfaces from doctrine/persistence 4:
  - MutableAclProvider::propertyChanged() (implements PropertyChangedListener interface)
  - Acl::addPropertyChangedListener() (implements NotifyPropertyChanged interface)
- Fixed foreign key constraints in Schema.php to use table names instead of Table objects (DBAL 4 requirement)

Note: The return type annotations are now required (not optional) because the interfaces in doctrine/persistence 4 have these return types defined. Without them, PHP will throw a fatal error about incompatible method signatures.